### PR TITLE
MX5: Add Flash from USB functionality

### DIFF
--- a/recipes-bsp/u-boot/files/mx6/0001-Add-mx5-defconfig.patch
+++ b/recipes-bsp/u-boot/files/mx6/0001-Add-mx5-defconfig.patch
@@ -13,7 +13,7 @@ new file mode 100644
 index 0000000000..def79d7954
 --- /dev/null
 +++ b/configs/mx5_imx6qp_defconfig
-@@ -0,0 +1,91 @@
+@@ -0,0 +1,92 @@
 +CONFIG_ARM=y
 +# CONFIG_SPL_SYS_THUMB_BUILD is not set
 +CONFIG_ARCH_MX6=y
@@ -62,6 +62,7 @@ index 0000000000..def79d7954
 +CONFIG_CMD_EXT4_WRITE=y
 +CONFIG_CMD_FAT=y
 +CONFIG_CMD_FS_GENERIC=y
++CONFIG_CMD_UNZIP=y
 +CONFIG_EFI_PARTITION=y
 +CONFIG_OF_CONTROL=y
 +CONFIG_DEFAULT_DEVICE_TREE="mx5_imx6qp"

--- a/recipes-bsp/u-boot/files/mx6/0003-Add-mx5-uboot-and-spl-implementation.patch
+++ b/recipes-bsp/u-boot/files/mx6/0003-Add-mx5-uboot-and-spl-implementation.patch
@@ -1059,7 +1059,7 @@ new file mode 100644
 index 0000000000..193cab5bee
 --- /dev/null
 +++ b/include/configs/mx5_imx6_common.h
-@@ -0,0 +1,101 @@
+@@ -0,0 +1,106 @@
 +/* SPDX-License-Identifier: GPL-2.0+ */
 +/*
 + * Copyright (C) 2012 Freescale Semiconductor, Inc.
@@ -1149,12 +1149,17 @@ index 0000000000..193cab5bee
 +		"root=${mmcroot}\0" \
 +	"loadimage=fatload mmc ${mmcdev}:${mmcpart} ${loadaddr} ${image}\0" \
 +	"loadfdt=fatload mmc ${mmcdev}:${mmcpart} ${fdt_addr} ${fdt_file}\0" \
++	"flash_wanted=i2c dev 2 && setexpr p ${loadaddr} + 4 && mw ${p} 1 && i2c read 0x46 2.2 1 ${loadaddr} && cmp.b ${loadaddr} ${p} 1\0" \
++	"flash_script_name=flashmx5.scr\0" \
++	"flash_script_addr=0x10700000\0" \
++	"try_flash=usb start; if fatload usb 0 ${flash_script_addr} ${flash_script_name} ; then source ${flash_script_addr}; else echo UPDATE ERROR: no ${flash_script_name} on first USB device.;fi\0" \
 +	"mmcboot=echo Booting from mmc ...; " \
 +		"run mmcargs; " \
 +		"bootz ${loadaddr} - ${fdt_addr};\0" \
 +	"ums=mmc dev 2 && mmc partconf 2 1 0 0 && ums 0 mmc 2"
 +
 +#define CONFIG_BOOTCOMMAND \
++	"run flash_wanted && run try_flash; " \
 +	"mmc dev ${mmcdev};" \
 +	"run loadimage;" \
 +	"run loadfdt;" \

--- a/recipes-bsp/u-boot/files/mx6/flashmx5.cmd
+++ b/recipes-bsp/u-boot/files/mx6/flashmx5.cmd
@@ -1,0 +1,22 @@
+# i2c variables TODO this is realtime clock, change to co-cpu. TODO Need rewrite when co-cpu i2c protocol is ready. 
+env set i2c_bus 2
+env set i2c_dev 0x46
+env set update_wanted_i2c_register 0x0002
+env set usbdev 0
+env set usbpart 1
+env set wic_file mx5-image.wic.gz
+
+#start USB device and try to load wic_file into memory if load fails, exit the scipt (and boot normaly).
+env set loadimage_usb "usb start; fatload usb ${usbdev}:${usbpart} ${loadaddr} ${wic_file}"
+echo Loading ${wic_file} from USB ${usbdev}:${usbpart};
+if run loadimage_usb; then echo load ok; else echo load failed, aborting; exit; fi
+
+#write the image onto the mmc. if it fails exit the script (and boot normally). TODO add a retry? TODO check checksum
+env set writeimage "gzwrite mmc ${mmcdev} ${loadaddr} 0x${filesize} 100000 0"
+echo Extracting ${wic_file} to mmc ${mmcdev};
+if run writeimage; then echo write ok; else echo write failed, aborting; exit; fi
+
+echo Resetting update flags;
+# Write a zero  to the update_wanted i2c register(.2 means 16 bit wide register)
+i2c mw ${i2c_dev} ${update_wanted_i2c_register}.2 0 1 || echo 'FLASH MX5_SCRIPT ERROR: Could not reset update flag'
+

--- a/recipes-bsp/u-boot/u-boot-hostmobility-flash-mx5.bb
+++ b/recipes-bsp/u-boot/u-boot-hostmobility-flash-mx5.bb
@@ -1,0 +1,20 @@
+SUMMARY = "U-boot update script for mx5"
+LICENSE = "CLOSED"
+
+SRC_URI = "file://flashmx5.cmd"
+
+DEPENDS = "u-boot-mkimage-native"
+
+
+do_compile() {
+    uboot-mkimage -A arm -T script -C none -n "Update script" -d "${WORKDIR}/flashmx5.cmd" flashmx5.scr
+}
+
+inherit deploy
+
+do_deploy() {
+    install -d ${DEPLOYDIR}
+    install -m 0644 flashmx5.scr ${DEPLOYDIR}
+}
+
+addtask do_deploy after do_compile before do_build


### PR DESCRIPTION
Add a check from U-Boot to the CO-CPU that checks if the user has pushed
the reset button or otherwise set CO-CPU I2C register 2 to 1 to indicate that
the a re-programming from an image file shall be done. The check is done
in the bootcmd environmental variable.

If the MX5 shall be flashed, a script with the name flashmx5.scr(created
from flashmx5.cmd) is expected to be found on the first detected USB
flash memory. The script handles the flashing sequence by loading the
image file that shall be programmed on the eMMC of the MX5. The image
file shall have the name mx5-image.wic.gz

To trigger an update:
* Place flashmx5.cmd and mx5-image.wic.gz on an USB memory.
* Insert the USB memory into the MX-5
* Press the reset button
* Alternatively, use i2ctransfer -y 2 w3@0x46 0 2 1 and restart