### PR TITLE
Fix some warnings by updating the bitbake syntax

### DIFF
--- a/conf/machine/include/mx4-tegra-base.inc
+++ b/conf/machine/include/mx4-tegra-base.inc
@@ -21,7 +21,7 @@ PREFERRED_PROVIDER_virtual/kernel = "linux-hostmobility"
 KERNEL_IMAGETYPE = "uImage"
 
 # The kernel lives in a seperate FAT or UBI partition, don't deploy it in /boot
-RDEPENDS_kernel-base = ""
+RDEPENDS_${KERNEL_PACKAGE_NAME}-base = ""
 
 PREFERRED_PROVIDER_u-boot = "u-boot-hostmobility"
 PREFERRED_PROVIDER_virtual/bootloader = "u-boot-hostmobility"

--- a/conf/machine/include/mx4-vf-base.inc
+++ b/conf/machine/include/mx4-vf-base.inc
@@ -9,7 +9,7 @@ PREFERRED_PROVIDER_virtual/kernel ?= "linux-hostmobility-vf"
 KERNEL_IMAGETYPE = "zImage"
 
 # We store kernel on seperate MTD partition so no need to deploy to rootfs.
-RDEPENDS_kernel-base = ""
+RDEPENDS_${KERNEL_PACKAGE_NAME}-base = ""
 
 PREFERRED_PROVIDER_u-boot ?= "u-boot-hostmobility"
 PREFERRED_PROVIDER_virtual/bootloader ?= "u-boot-hostmobility"


### PR DESCRIPTION
This replaces the old variable key RDEPENDS_kernel-base
with RDEPENDS_${KERNEL_PACKAGE_NAME}-base