### PR TITLE
Rename MX-5 into MX-V and change hostname to mxv-pt

### DIFF
--- a/conf/machine/mx5-pt.conf
+++ b/conf/machine/mx5-pt.conf
@@ -1,7 +1,7 @@
 #@TYPE: Machine
-#@NAME: Host Mobility MX-5-pt 
+#@NAME: Host Mobility MX-V PT
 #@SOC: iMx6
-#@DESCRIPTION: Machine configuration for Host Mobility MX-5-pt 
+#@DESCRIPTION: Machine configuration for Host Mobility MX-V PT
 
 include conf/machine/include/mx5-base.inc
 
@@ -11,10 +11,12 @@ PREFERRED_PROVIDER_virtual/kernel = "linux-mobility-imx"
 
 UBOOT_MACHINE ?= "mx5_imx6qp_defconfig"
 
-
 ##UBOOT_MAKE_TARGET = "all"
 UBOOT_SUFFIX = "img"
 SPL_BINARY = "SPL"
 IMAGE_BOOT_FILES = "zImage imx6qp-mx5.dtb"
 
 MACHINE_FEATURES += "usbgadget usbhost vfat rtc wifi alsa j1708 hm-cocpu_updater hm-cocpu_updater-service"
+
+# Use a custom hostname
+hostname:pn-base-files = "mxv-pt"

--- a/recipes-hostmobility/packagegroups/packagegroup-hostmobility-commercial-mx5.bb
+++ b/recipes-hostmobility/packagegroups/packagegroup-hostmobility-commercial-mx5.bb
@@ -1,4 +1,4 @@
-SUMMARY = "MX-5 Commercial package group"
+SUMMARY = "MX-V Commercial package group"
 DESCRIPTION = "Package group bringing in packages that are closed source and part of BSP"
 
 inherit packagegroup


### PR DESCRIPTION
Replace "MX-5" with "MX-V" in machine description but keep
"mx5-pt" as the machine name used in the build system.

In addition, set the hostname to "mxv-pt". This overrides the machine
name.