### PR TITLE
Add gpio-poweroff handler that pulls GPIO4_IO19

### DIFF
--- a/recipes-kernel/linux/linux-variscite/0001-add-hmx-device-tree.patch
+++ b/recipes-kernel/linux/linux-variscite/0001-add-hmx-device-tree.patch
@@ -1,7 +1,7 @@
-From 13d9027c9e8a90005cf30c1e438c109051b82e43 Mon Sep 17 00:00:00 2001
+From 69c5e68f27a3b4b9c80ce766fe0f7b249872e798 Mon Sep 17 00:00:00 2001
 From: rikardo <rikard.olander@hostmobility.com>
 Date: Thu, 2 Mar 2023 16:01:48 +0000
-Subject: [PATCH 1/1] add hmx device tree
+Subject: [PATCH] add hmx device tree
 
 v1.  Files merged to single file.
 	0004-HMX-DT-update-for-ethernet-on-USB.patch
@@ -34,10 +34,15 @@ v7. Fix rtc and acc IRQ and declared SE05.
     Can_wake_extern: set to individual pinctrl and change logic to GPIO_ACTIVE_LOW(inverted signal).
     Still driver(tcan4x5x) needs to be updated to make this signal toggle at a correct minimum time.
     Turned off leds so only one led is set to heartbeat and the rest is off from start.
+
+v8. Add gpio-poweroff handler that pulls GPIO4_IO19 (POWER_OFF) low to
+    completely turn off the board. NOTE: another pm_power_off handler is
+    already registered and gpio-poweroff.c needs to be patched to
+    overwrite it (/* If a pm_power_off function has already been added, leave it alone */)
 ---
  arch/arm64/boot/dts/freescale/Makefile        |    2 +
- .../dts/freescale/imx8mp-var-dart-hmx1.dts    | 1180 +++++++++++++++++
- 2 files changed, 1182 insertions(+)
+ .../dts/freescale/imx8mp-var-dart-hmx1.dts    | 1194 +++++++++++++++++
+ 2 files changed, 1196 insertions(+)
  create mode 100644 arch/arm64/boot/dts/freescale/imx8mp-var-dart-hmx1.dts
 
 diff --git a/arch/arm64/boot/dts/freescale/Makefile b/arch/arm64/boot/dts/freescale/Makefile
@@ -52,10 +57,10 @@ index 6ce43e6646ea..9e92208b3a14 100644
 +dtb-$(CONFIG_ARCH_MXC) += imx8mp-var-dart-hmx1.dtb
 diff --git a/arch/arm64/boot/dts/freescale/imx8mp-var-dart-hmx1.dts b/arch/arm64/boot/dts/freescale/imx8mp-var-dart-hmx1.dts
 new file mode 100644
-index 000000000000..2c124ddf7f46
+index 000000000000..5e5fe35e1da2
 --- /dev/null
 +++ b/arch/arm64/boot/dts/freescale/imx8mp-var-dart-hmx1.dts
-@@ -0,0 +1,1180 @@
+@@ -0,0 +1,1194 @@
 +// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
 +/*
 + * Copyright 2022 Host Mobility AB
@@ -327,6 +332,14 @@ index 000000000000..2c124ddf7f46
 +		compatible = "fixed-clock";
 +		#clock-cells = <0>;
 +		clock-frequency = <40000000>;
++	};
++
++	gpio-poweroff {
++		compatible = "gpio-poweroff";
++		pinctrl-0 = <&pinctrl_power_off>;
++		gpios = <&gpio4 19 GPIO_ACTIVE_LOW>;
++		timeout-ms = <3000>;
++		force-mode;
 +	};
 +};
 +
@@ -1039,6 +1052,12 @@ index 000000000000..2c124ddf7f46
 +			MX8MP_IOMUXC_SAI3_TXD__GPIO5_IO01	(PE_1_PULL_ENABLE | HYS_1_SCHMITT | DSE_X6)
 +		>;
 +	};
++
++	pinctrl_power_off: power_off_group {
++		fsl,pins = <
++			MX8MP_IOMUXC_SAI1_TXD7__GPIO4_IO19	(ODE_1_OPEN_DRAIN_ENABLE)
++		>;
++	};
 +};
 +
 +&gpio1 {
@@ -1237,5 +1256,5 @@ index 000000000000..2c124ddf7f46
 +};
 +
 -- 
-2.17.1
+2.30.2
 

--- a/recipes-kernel/linux/linux-variscite/0018-power-reset-gpio-poweroff-add-force-mode.patch
+++ b/recipes-kernel/linux/linux-variscite/0018-power-reset-gpio-poweroff-add-force-mode.patch
@@ -1,0 +1,85 @@
+From f19ecb10409cc96ee83ac72fdc1cb20b1d36d3b7 Mon Sep 17 00:00:00 2001
+From: Mattias Busck <mattias.busck@hostmobility.com>
+Date: Wed, 14 Mar 2023 06:45:03 +0100
+Subject: [PATCH] power reset gpio poweroff add force mode
+
+Property "force-mode" tells the driver to replace previously
+initialized power-off kernel hook and allows gpio-poweroff to
+probe and operate successfully in any case.
+
+original by Oleksandr Suvorov <oleksandr.suvorov@toradex.com>
+---
+
+ drivers/power/reset/gpio-poweroff.c | 34 ++++++++++++++++++++++++-----
+ 1 file changed, 28 insertions(+), 6 deletions(-)
+
+diff --git a/drivers/power/reset/gpio-poweroff.c b/drivers/power/reset/gpio-poweroff.c
+index 6a4bbb506551..94056af9ba0d 100644
+--- a/drivers/power/reset/gpio-poweroff.c
++++ b/drivers/power/reset/gpio-poweroff.c
+@@ -24,6 +24,7 @@ static struct gpio_desc *reset_gpio;
+ static u32 timeout = DEFAULT_TIMEOUT_MS;
+ static u32 active_delay = 100;
+ static u32 inactive_delay = 100;
++static void (*next_pm_power_off)(void);
+ 
+ static void gpio_poweroff_do_poweroff(void)
+ {
+@@ -43,20 +44,41 @@ static void gpio_poweroff_do_poweroff(void)
+ 	/* give it some time */
+ 	mdelay(timeout);
+ 
++	/*
++	 * The kernel should not reach this code. If it does, fall back to
++	 * the next registered power off method.
++	 */
++	if (next_pm_power_off)
++		next_pm_power_off();
++
+ 	WARN_ON(1);
+ }
+ 
+ static int gpio_poweroff_probe(struct platform_device *pdev)
+ {
+ 	bool input = false;
++	bool force = false;
+ 	enum gpiod_flags flags;
+ 
+-	/* If a pm_power_off function has already been added, leave it alone */
++
++	force = device_property_read_bool(&pdev->dev, "force-mode");
++
++	/*
++	 * If a pm_power_off function has already been added, leave it alone,
++	 * if force-mode is not enabled.
++	 */
+ 	if (pm_power_off != NULL) {
+-		dev_err(&pdev->dev,
+-			"%s: pm_power_off function already registered\n",
+-		       __func__);
+-		return -EBUSY;
++		if (force) {
++			dev_warn(&pdev->dev,
++				 "%s: pm_power_off function %pB replaced",
++				 __func__, pm_power_off);
++			next_pm_power_off = pm_power_off;
++		} else {
++			dev_err(&pdev->dev,
++				"%s: pm_power_off function already registered\n",
++				__func__);
++			return -EBUSY;
++		}
+ 	}
+ 
+ 	input = device_property_read_bool(&pdev->dev, "input");
+@@ -81,7 +103,7 @@ static int gpio_poweroff_probe(struct platform_device *pdev)
+ static int gpio_poweroff_remove(struct platform_device *pdev)
+ {
+ 	if (pm_power_off == &gpio_poweroff_do_poweroff)
+-		pm_power_off = NULL;
++		pm_power_off = next_pm_power_off;
+ 
+ 	return 0;
+ }
+-- 
+2.20.1

--- a/recipes-kernel/linux/linux-variscite_%.bbappend
+++ b/recipes-kernel/linux/linux-variscite_%.bbappend
@@ -9,6 +9,7 @@ file://0001-TCAN114x-driver-with-normal-standby-sleep-mode.patch \
 file://0009-Fix-tcan114x_mode_store-for-sleep-standby.patch \
 file://0016-improve-tcan4x5x-spi-performance.-coalesce-irqs.patch \
 file://0017-Add-suspend-to-optimized-tcan4x5x-driver.patch \
+file://0018-power-reset-gpio-poweroff-add-force-mode.patch  \
 "
 # file://0011-Add-control-for-selective-wakeup.patch
 # file://0008-Add-suspend-to-tcan4x5x-driver.patch 


### PR DESCRIPTION
Add gpio-poweroff handler that pulls GPIO4_IO19 to completely turn off the board. NOTE: another pm_power_off handler is already registered and gpio-poweroff.c needs to be patched to overwrite it.

The power-off functions seems to be the handled by the psci driver that turns off the CPU but we pull the gpio and turn off the power instead.

Reference:
https://www.thegoodpenguin.co.uk/blog/an-overview-of-psci/

A question is should we allow power-off when KL15/start-signal is on.