### PR TITLE
HMX: patch gpio-keys: make disabled keys not wake system

### DIFF
--- a/recipes-kernel/linux/linux-variscite/0001-add-hmx-device-tree.patch
+++ b/recipes-kernel/linux/linux-variscite/0001-add-hmx-device-tree.patch
@@ -1,4 +1,4 @@
-From 69c5e68f27a3b4b9c80ce766fe0f7b249872e798 Mon Sep 17 00:00:00 2001
+From e278ae9eaa59f3c9ecb920a6d2b98d4c22097ff2 Mon Sep 17 00:00:00 2001
 From: rikardo <rikard.olander@hostmobility.com>
 Date: Thu, 2 Mar 2023 16:01:48 +0000
 Subject: [PATCH] add hmx device tree
@@ -39,10 +39,13 @@ v8. Add gpio-poweroff handler that pulls GPIO4_IO19 (POWER_OFF) low to
     completely turn off the board. NOTE: another pm_power_off handler is
     already registered and gpio-poweroff.c needs to be patched to
     overwrite it (/* If a pm_power_off function has already been added, leave it alone */)
+
+v9. Make it possible to disable in_start and the other gpiokeys with
+    linux,can-disable = <1>;
 ---
  arch/arm64/boot/dts/freescale/Makefile        |    2 +
- .../dts/freescale/imx8mp-var-dart-hmx1.dts    | 1194 +++++++++++++++++
- 2 files changed, 1196 insertions(+)
+ .../dts/freescale/imx8mp-var-dart-hmx1.dts    | 1203 +++++++++++++++++
+ 2 files changed, 1205 insertions(+)
  create mode 100644 arch/arm64/boot/dts/freescale/imx8mp-var-dart-hmx1.dts
 
 diff --git a/arch/arm64/boot/dts/freescale/Makefile b/arch/arm64/boot/dts/freescale/Makefile
@@ -57,10 +60,10 @@ index 6ce43e6646ea..9e92208b3a14 100644
 +dtb-$(CONFIG_ARCH_MXC) += imx8mp-var-dart-hmx1.dtb
 diff --git a/arch/arm64/boot/dts/freescale/imx8mp-var-dart-hmx1.dts b/arch/arm64/boot/dts/freescale/imx8mp-var-dart-hmx1.dts
 new file mode 100644
-index 000000000000..5e5fe35e1da2
+index 000000000000..a10734241650
 --- /dev/null
 +++ b/arch/arm64/boot/dts/freescale/imx8mp-var-dart-hmx1.dts
-@@ -0,0 +1,1194 @@
+@@ -0,0 +1,1203 @@
 +// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
 +/*
 + * Copyright 2022 Host Mobility AB
@@ -117,6 +120,7 @@ index 000000000000..5e5fe35e1da2
 +		in_start {
 +			label = "IN_START";
 +			linux,code = <KEY_MACRO1>;
++			linux,can-disable = <1>;
 +			gpios = <&gpio4 21 GPIO_ACTIVE_HIGH>;
 +			wakeup-source;
 +			debounce-interval = <100>;
@@ -126,6 +130,7 @@ index 000000000000..5e5fe35e1da2
 +		in_pulldown1 {
 +			label = "IN_PULLDOWN1";
 +			linux,code = <KEY_MACRO2>;
++			linux,can-disable = <1>;
 +			gpios = <&gpio4 3 GPIO_ACTIVE_HIGH>;
 +			wakeup-source;
 +			debounce-interval = <100>;
@@ -135,6 +140,7 @@ index 000000000000..5e5fe35e1da2
 +		in_pulldown2 {
 +			label = "IN_PULLDOWN2";
 +			linux,code = <KEY_MACRO3>;
++			linux,can-disable = <1>;
 +			gpios = <&gpio4 2 GPIO_ACTIVE_HIGH>;
 +			wakeup-source;
 +			debounce-interval = <100>;
@@ -144,6 +150,7 @@ index 000000000000..5e5fe35e1da2
 +		in_pullup1 {
 +			label = "IN_PULLUP1";
 +			linux,code = <KEY_MACRO4>;
++			linux,can-disable = <1>;
 +			gpios = <&gpio3 20 GPIO_ACTIVE_HIGH>;
 +			wakeup-source;
 +			debounce-interval = <100>;
@@ -153,6 +160,7 @@ index 000000000000..5e5fe35e1da2
 +		in_pullup2 {
 +			label = "IN_PULLUP2";
 +			linux,code = <KEY_MACRO5>;
++			linux,can-disable = <1>;
 +			gpios = <&gpio3 22 GPIO_ACTIVE_HIGH>;
 +			wakeup-source;
 +			debounce-interval = <100>;
@@ -162,6 +170,7 @@ index 000000000000..5e5fe35e1da2
 +		in_hmi1 {
 +			label = "IN_HMI1";
 +			linux,code = <KEY_MACRO6>;
++			linux,can-disable = <1>;
 +			gpios = <&gpio4 0 GPIO_ACTIVE_HIGH>;
 +			wakeup-source;
 +			debounce-interval = <100>;
@@ -171,6 +180,7 @@ index 000000000000..5e5fe35e1da2
 +		in_hmi2 {
 +			label = "IN_HMI2";
 +			linux,code = <KEY_MACRO7>;
++			linux,can-disable = <1>;
 +			gpios = <&gpio4 1 GPIO_ACTIVE_HIGH>;
 +			wakeup-source;
 +			debounce-interval = <100>;
@@ -182,12 +192,14 @@ index 000000000000..5e5fe35e1da2
 +			label = "5V_nDROP_OUT";
 +			gpios = <&gpio1 13 GPIO_ACTIVE_LOW>;
 +			linux,code = <KEY_RESTART>;
++			linux,can-disable = <1>;
 +			debounce-interval = <250>;//250ms low to activate restart.
 +		};
 +		usb_boot_button {
 +			label = "SOFT_RESTART_BUTTON_USB_BOOT";
 +			gpios = <&gpio3 0 GPIO_ACTIVE_LOW>;
 +			linux,code = <KEY_RESTART>;
++			linux,can-disable = <1>;
 +			debounce-interval = <500>;//500ms low to activate restart.
 +		};
 +	};

--- a/recipes-kernel/linux/linux-variscite/0022-gpio-keys-make-disabled-keys-not-wake-system.patch
+++ b/recipes-kernel/linux/linux-variscite/0022-gpio-keys-make-disabled-keys-not-wake-system.patch
@@ -1,0 +1,32 @@
+From 788e61a136a61fb6740b5ea077910938cff7e611 Mon Sep 17 00:00:00 2001
+From: Mattias Busck <mattias.busck@hostmobility.com>
+Date: Tue, 28 Mar 2023 16:42:25 +0200
+Subject: [PATCH] gpio-keys: make disabled keys not wake system
+
+Keys can be disabled from generating event, e.g. when KEY_MACRO1(defined
+in /usr/include/linux/input-event-codes.h) is mapped to IN_START, the
+following line will stop it from generating events in /dev/input/event1.
+However, the system still wakes up.
+echo 656 >/sys/devices/platform/gpio-keys/disabled_keys
+
+Modify driver so wake-up only occurs if a key has NOT been disabled.
+---
+ drivers/input/keyboard/gpio_keys.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/drivers/input/keyboard/gpio_keys.c b/drivers/input/keyboard/gpio_keys.c
+index 22a91db645b8..32016efc375b 100644
+--- a/drivers/input/keyboard/gpio_keys.c
++++ b/drivers/input/keyboard/gpio_keys.c
+@@ -957,7 +957,7 @@ gpio_keys_enable_wakeup(struct gpio_keys_drvdata *ddata)
+ 
+ 	for (i = 0; i < ddata->pdata->nbuttons; i++) {
+ 		bdata = &ddata->data[i];
+-		if (bdata->button->wakeup) {
++		if (bdata->button->wakeup && !bdata->disabled) {
+ 			error = gpio_keys_button_enable_wakeup(bdata);
+ 			if (error)
+ 				goto err_out;
+-- 
+2.30.2
+

--- a/recipes-kernel/linux/linux-variscite_%.bbappend
+++ b/recipes-kernel/linux/linux-variscite_%.bbappend
@@ -10,6 +10,7 @@ file://0009-Fix-tcan114x_mode_store-for-sleep-standby.patch \
 file://0016-improve-tcan4x5x-spi-performance.-coalesce-irqs.patch \
 file://0017-Add-suspend-to-optimized-tcan4x5x-driver.patch \
 file://0018-power-reset-gpio-poweroff-add-force-mode.patch  \
+file://0022-gpio-keys-make-disabled-keys-not-wake-system.patch  \
 "
 # file://0011-Add-control-for-selective-wakeup.patch
 # file://0008-Add-suspend-to-tcan4x5x-driver.patch 


### PR DESCRIPTION
* Update device tree so keys can be disabled
* Modify driver so wake-up only occurs if a key has NOT been disabled.