### PR TITLE
HMx uboot: fix auto detect right rgb LED ID

### DIFF
--- a/dynamic-layers/recipes-bsp/u-boot/u-boot-variscite/0003-HMX-custom-imx8mp_var_dart.patch
+++ b/dynamic-layers/recipes-bsp/u-boot/u-boot-variscite/0003-HMX-custom-imx8mp_var_dart.patch
@@ -20,9 +20,9 @@ Add RGB LED handling. Set it to blue on boot and if
 we start to reflash set it to white with blink.
 Add watchdog_init
 ---
- .../imx8mp_var_dart/imx8mp_var_dart.c         | 89 ++++++++++++++++++-
+ .../imx8mp_var_dart/imx8mp_var_dart.c         | 90 ++++++++++++++++++-
  include/configs/imx8mp_var_dart.h             | 22 +++--
- 2 files changed, 102 insertions(+), 9 deletions(-)
+ 2 files changed, 103 insertions(+), 9 deletions(-)
 
 diff --git a/board/variscite/imx8mp_var_dart/imx8mp_var_dart.c b/board/variscite/imx8mp_var_dart/imx8mp_var_dart.c
 index e1a1215536..5adf71df87 100644
@@ -211,17 +211,18 @@ index 85b4eb6100..a6e7e5bfcf 100644
  				"else " \
  					"setenv fdt_file imx8mp-var-dart-dt8mcustomboard.dtb;" \
  				"fi; " \
-@@ -181,7 +181,12 @@
+@@ -181,7 +181,13 @@
  				"echo WARN: Cannot load the DT; " \
  			"fi; " \
  		"fi;\0" \
 -	"bsp_bootcmd=echo Running BSP bootcmd ...; " \
-+	"set_blue_led=i2c dev 1; if i2c probe 0x30 ; then i2c mw 0x30 6.1 0x50 1;i2c mw 0x30 4.1 1 1;fi\0" \
-+	"set_white_flashing_led=i2c dev 1; if i2c probe 0x30 ; then i2c mw 0x30 6.1 0x50 1;i2c mw 0x30 7.1 0x50 1;i2c mw 0x30 8.1 0x50 1;i2c mw 0x30 4.1 0x2A 1;i2c mw 0x30 1.1 13 1;fi\0" \
-+	"set_red_led=i2c mw 0x30 7.1 0x50 1;i2c mw 0x30 4.1 0x4 1\0" \
-+	"white_blink_fast=i2c mw 0x30 1.1 1 1\0" \
++	"set_blue_led=i2c dev 1; if i2c probe ${RGB_I2C_ID} ; then i2c mw ${RGB_I2C_ID} 6.1 0x50 1;i2c mw ${RGB_I2C_ID} 4.1 1 1;fi\0" \
++	"set_white_flashing_led=i2c dev 1; if i2c probe ${RGB_I2C_ID} ; then i2c mw ${RGB_I2C_ID} 6.1 0x50 1;i2c mw ${RGB_I2C_ID} 7.1 0x50 1;i2c mw ${RGB_I2C_ID} 8.1 0x50 1;i2c mw ${RGB_I2C_ID} 4.1 0x2A 1;i2c mw ${RGB_I2C_ID} 1.1 13 1;fi\0" \
++	"set_red_led=i2c mw ${RGB_I2C_ID} 7.1 0x50 1;i2c mw ${RGB_I2C_ID} 4.1 0x4 1\0" \
++	"white_blink_fast=i2c mw ${RGB_I2C_ID} 1.1 1 1\0" \
 +	"try_usb_flash=sleep 2; usb reset; if load usb 0 ${loadaddr} ${bsp_script} ; then source ${loadaddr}; else echo UPDATE ERROR: no ${bsp_script} on first USB device. ;fi\0" \
-+	"bsp_bootcmd=echo Running BSP bootcmd ...; run set_blue_led; " \
++	"set_RGB_ID=i2c dev 1; i2c probe 0x30 && setenv RGB_I2C_ID 0x30 || i2c probe 0x31 && setenv RGB_I2C_ID 0x31 || i2c probe 0x32 && setenv RGB_I2C_ID 0x32; if test -n \"${RGB_I2C_ID}\" ; then setenv first_time_boot_fix_RGB_ID 'i2c dev 1; echo RGB ID:$RGB_I2C_ID;'; saveenv;fi\0" \
++	"bsp_bootcmd=echo Running BSP bootcmd ...; run set_RGB_ID; run set_blue_led; " \
  		"run ramsize_check; " \
  		"mmc dev ${mmcdev}; " \
  		"if mmc rescan; then " \

--- a/recipes-bsp/flash-script/flash-script/imx8mp-var-dart-hmx1/flash.cmd
+++ b/recipes-bsp/flash-script/flash-script/imx8mp-var-dart-hmx1/flash.cmd
@@ -1,10 +1,10 @@
 env set usbdev 0
 env set usbpart 1
 env set wic_file hmx-image.wic.gz
-env set set_red_led "i2c mw 0x30 7.1 0x50 1;i2c mw 0x30 4.1 0x4 1"
+env set set_red_led "i2c mw ${RGB_I2C_ID} 7.1 0x50 1;i2c mw ${RGB_I2C_ID} 4.1 0x4 1"
 
 #set white led flashing faster.
-env set white_blink_fast "i2c mw 0x30 1.1 1 1;"
+env set white_blink_fast "i2c mw ${RGB_I2C_ID} 1.1 1 1;"
 run set_white_flashing_led; 
 run white_blink_fast;
 

--- a/recipes-bsp/hm-autostart/hm-autostart/autostart.sh
+++ b/recipes-bsp/hm-autostart/hm-autostart/autostart.sh
@@ -4,8 +4,14 @@ WORKING_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 #set RGB LED Green
 if [[ "$(cat /etc/platform-system-type)" == "imx8mp-var-dart-hmx1" ]]; then
-    i2cset -y 1 0x30 8 0x50;
-    i2cset -y 1 0x30 4 0x10;
+	RGB_I2C_ID=$(fw_printenv RGB_I2C_ID | sed 's/RGB_I2C_ID=//')
+	if [[ -z "$RGB_I2C_ID" ]]; then
+		i2cset -y 1 0x32 8 0x50;
+		i2cset -y 1 0x32 4 0x10;
+	else
+		i2cset -y 1 ${RGB_I2C_ID} 8 0x50;
+		i2cset -y 1 ${RGB_I2C_ID} 4 0x10;
+	fi
 fi
 
 FIRST_TIME_BOOT_FILE=/etc/first_boot_after_update.txt


### PR DESCRIPTION
Using set_RGB_ID to first probe for all known Ids and if it is found set it to RGB_I2C_ID
(will be used in flash.cmd and linux autostart.sh) and save enviorment.
set_RGB_ID will on success found this RGB. set to
i2c dev 1; echo RGB ID:$RGB_I2C_ID; for later prints when bsp_bootcmd is running.