### PR TITLE
Hmx backport tcan4x5x from linux can6 2

### DIFF
--- a/dynamic-layers/recipes-kernel/linux/linux-variscite/0020-HMX-backport-m_can-from-linux-can-next.patch
+++ b/dynamic-layers/recipes-kernel/linux/linux-variscite/0020-HMX-backport-m_can-from-linux-can-next.patch
@@ -1,0 +1,862 @@
+From 764c76fa6f0a5b74b9c1380af78bda317d41c9b9 Mon Sep 17 00:00:00 2001
+From: Mattias Busck <mattias.busck@hostmobility.com>
+Date: Thu, 23 Mar 2023 15:02:34 +0100
+Subject: [PATCH] HMX:backport m_can from linux-can-next
+
+repo: git://git.kernel.org/pub/scm/linux/kernel/git/mkl/linux-can-next
+tag: linux-can-next-for-6.3-20230217
+---
+ drivers/net/can/m_can/Kconfig           |   1 +
+ drivers/net/can/m_can/m_can.c           | 221 +++++++++++++-----------
+ drivers/net/can/m_can/m_can.h           |  22 +--
+ drivers/net/can/m_can/m_can_pci.c       |   9 +-
+ drivers/net/can/m_can/m_can_platform.c  |   6 +-
+ drivers/net/can/m_can/tcan4x5x-core.c   |  20 +--
+ drivers/net/can/m_can/tcan4x5x-regmap.c |  47 ++++-
+ 7 files changed, 182 insertions(+), 144 deletions(-)
+
+diff --git a/drivers/net/can/m_can/Kconfig b/drivers/net/can/m_can/Kconfig
+index 45ad1b3f0cd0..fc2afab36279 100644
+--- a/drivers/net/can/m_can/Kconfig
++++ b/drivers/net/can/m_can/Kconfig
+@@ -1,6 +1,7 @@
+ # SPDX-License-Identifier: GPL-2.0-only
+ menuconfig CAN_M_CAN
+ 	tristate "Bosch M_CAN support"
++	select CAN_RX_OFFLOAD
+ 	help
+ 	  Say Y here if you want support for Bosch M_CAN controller framework.
+ 	  This is common support for devices that embed the Bosch M_CAN IP.
+diff --git a/drivers/net/can/m_can/m_can.c b/drivers/net/can/m_can/m_can.c
+index c4596fbe6d2f..d7bb65fe1266 100644
+--- a/drivers/net/can/m_can/m_can.c
++++ b/drivers/net/can/m_can/m_can.c
+@@ -9,19 +9,20 @@
+  */
+ 
+ #include <linux/bitfield.h>
++#include <linux/can/dev.h>
++#include <linux/ethtool.h>
+ #include <linux/interrupt.h>
+ #include <linux/io.h>
++#include <linux/iopoll.h>
+ #include <linux/kernel.h>
+ #include <linux/module.h>
+ #include <linux/netdevice.h>
+ #include <linux/of.h>
+ #include <linux/of_device.h>
++#include <linux/phy/phy.h>
++#include <linux/pinctrl/consumer.h>
+ #include <linux/platform_device.h>
+ #include <linux/pm_runtime.h>
+-#include <linux/iopoll.h>
+-#include <linux/can/dev.h>
+-#include <linux/pinctrl/consumer.h>
+-#include <linux/phy/phy.h>
+ 
+ #include "m_can.h"
+ 
+@@ -77,9 +78,6 @@ enum m_can_reg {
+ 	M_CAN_TXEFA	= 0xf8,
+ };
+ 
+-/* napi related */
+-#define M_CAN_NAPI_WEIGHT	64
+-
+ /* message ram configuration data length */
+ #define MRAM_CFG_LEN	8
+ 
+@@ -158,6 +156,7 @@ enum m_can_reg {
+ #define PSR_EW		BIT(6)
+ #define PSR_EP		BIT(5)
+ #define PSR_LEC_MASK	GENMASK(2, 0)
++#define PSR_DLEC_MASK	GENMASK(10, 8)
+ 
+ /* Interrupt Register (IR) */
+ #define IR_ALL_INT	0xffffffff
+@@ -211,7 +210,7 @@ enum m_can_reg {
+ 
+ /* Interrupts for version >= 3.1.x */
+ #define IR_ERR_LEC_31X	(IR_PED | IR_PEA)
+-#define IR_ERR_BUS_31X      (IR_ERR_LEC_31X | IR_WDI | IR_BEU | IR_BEC | \
++#define IR_ERR_BUS_31X	(IR_ERR_LEC_31X | IR_WDI | IR_BEU | IR_BEC | \
+ 			 IR_TOO | IR_MRAF | IR_TSW | IR_TEFL | IR_RF1L | \
+ 			 IR_RF0L)
+ #define IR_ERR_ALL_31X	(IR_ERR_STATE | IR_ERR_BUS_31X)
+@@ -370,9 +369,14 @@ m_can_txe_fifo_read(struct m_can_classdev *cdev, u32 fgi, u32 offset, u32 *val)
+ 	return cdev->ops->read_fifo(cdev, addr_offset, val, 1);
+ }
+ 
++static inline bool _m_can_tx_fifo_full(u32 txfqs)
++{
++	return !!(txfqs & TXFQS_TFQF);
++}
++
+ static inline bool m_can_tx_fifo_full(struct m_can_classdev *cdev)
+ {
+-	return !!(m_can_read(cdev, M_CAN_TXFQS) & TXFQS_TFQF);
++	return _m_can_tx_fifo_full(m_can_read(cdev, M_CAN_TXFQS));
+ }
+ 
+ static void m_can_config_endisable(struct m_can_classdev *cdev, bool enable)
+@@ -473,19 +477,16 @@ static void m_can_receive_skb(struct m_can_classdev *cdev,
+ 	}
+ }
+ 
+-static int m_can_read_fifo(struct net_device *dev, u32 rxfs)
++static int m_can_read_fifo(struct net_device *dev, u32 fgi)
+ {
+ 	struct net_device_stats *stats = &dev->stats;
+ 	struct m_can_classdev *cdev = netdev_priv(dev);
+ 	struct canfd_frame *cf;
+ 	struct sk_buff *skb;
+ 	struct id_and_dlc fifo_header;
+-	u32 fgi;
+ 	u32 timestamp = 0;
+ 	int err;
+ 
+-	/* calculate the fifo get index for where to read data */
+-	fgi = FIELD_GET(RXFS_FGI_MASK, rxfs);
+ 	err = m_can_fifo_read(cdev, fgi, M_CAN_FIFO_ID, &fifo_header, 2);
+ 	if (err)
+ 		goto out_fail;
+@@ -524,13 +525,10 @@ static int m_can_read_fifo(struct net_device *dev, u32 rxfs)
+ 				      cf->data, DIV_ROUND_UP(cf->len, 4));
+ 		if (err)
+ 			goto out_free_skb;
+-	}
+-
+-	/* acknowledge rx fifo 0 */
+-	m_can_write(cdev, M_CAN_RXF0A, fgi);
+ 
++		stats->rx_bytes += cf->len;
++	}
+ 	stats->rx_packets++;
+-	stats->rx_bytes += cf->len;
+ 
+ 	timestamp = FIELD_GET(RX_BUF_RXTS_MASK, fifo_header.dlc) << 16;
+ 
+@@ -550,7 +548,11 @@ static int m_can_do_rx_poll(struct net_device *dev, int quota)
+ 	struct m_can_classdev *cdev = netdev_priv(dev);
+ 	u32 pkts = 0;
+ 	u32 rxfs;
+-	int err;
++	u32 rx_count;
++	u32 fgi;
++	int ack_fgi = -1;
++	int i;
++	int err = 0;
+ 
+ 	rxfs = m_can_read(cdev, M_CAN_RXF0S);
+ 	if (!(rxfs & RXFS_FFL_MASK)) {
+@@ -558,18 +560,25 @@ static int m_can_do_rx_poll(struct net_device *dev, int quota)
+ 		return 0;
+ 	}
+ 
+-	while ((rxfs & RXFS_FFL_MASK) && (quota > 0)) {
+-		err = m_can_read_fifo(dev, rxfs);
++	rx_count = FIELD_GET(RXFS_FFL_MASK, rxfs);
++	fgi = FIELD_GET(RXFS_FGI_MASK, rxfs);
++
++	for (i = 0; i < rx_count && quota > 0; ++i) {
++		err = m_can_read_fifo(dev, fgi);
+ 		if (err)
+-			return err;
++			break;
+ 
+ 		quota--;
+ 		pkts++;
+-		rxfs = m_can_read(cdev, M_CAN_RXF0S);
++		ack_fgi = fgi;
++		fgi = (++fgi >= cdev->mcfg[MRAM_RXF0].num ? 0 : fgi);
+ 	}
+ 
+-	if (pkts)
+-		can_led_event(dev, CAN_LED_EVENT_RX);
++	if (ack_fgi != -1)
++		m_can_write(cdev, M_CAN_RXF0A, ack_fgi);
++
++	if (err)
++		return err;
+ 
+ 	return pkts;
+ }
+@@ -653,9 +662,6 @@ static int m_can_handle_lec_err(struct net_device *dev,
+ 		break;
+ 	}
+ 
+-	stats->rx_packets++;
+-	stats->rx_bytes += cf->len;
+-
+ 	if (cdev->is_peripheral)
+ 		timestamp = m_can_get_timestamp(cdev);
+ 
+@@ -712,7 +718,6 @@ static int m_can_handle_state_change(struct net_device *dev,
+ 				     enum can_state new_state)
+ {
+ 	struct m_can_classdev *cdev = netdev_priv(dev);
+-	struct net_device_stats *stats = &dev->stats;
+ 	struct can_frame *cf;
+ 	struct sk_buff *skb;
+ 	struct can_berr_counter bec;
+@@ -777,9 +782,6 @@ static int m_can_handle_state_change(struct net_device *dev,
+ 		break;
+ 	}
+ 
+-	stats->rx_packets++;
+-	stats->rx_bytes += cf->len;
+-
+ 	if (cdev->is_peripheral)
+ 		timestamp = m_can_get_timestamp(cdev);
+ 
+@@ -828,11 +830,9 @@ static void m_can_handle_other_err(struct net_device *dev, u32 irqstatus)
+ 		netdev_err(dev, "Message RAM access failure occurred\n");
+ }
+ 
+-static inline bool is_lec_err(u32 psr)
++static inline bool is_lec_err(u8 lec)
+ {
+-	psr &= LEC_UNUSED;
+-
+-	return psr && (psr != LEC_UNUSED);
++	return lec != LEC_NO_ERROR && lec != LEC_NO_CHANGE;
+ }
+ 
+ static inline bool m_can_is_protocol_err(u32 irqstatus)
+@@ -887,9 +887,20 @@ static int m_can_handle_bus_errors(struct net_device *dev, u32 irqstatus,
+ 		work_done += m_can_handle_lost_msg(dev);
+ 
+ 	/* handle lec errors on the bus */
+-	if ((cdev->can.ctrlmode & CAN_CTRLMODE_BERR_REPORTING) &&
+-	    is_lec_err(psr))
+-		work_done += m_can_handle_lec_err(dev, psr & LEC_UNUSED);
++	if (cdev->can.ctrlmode & CAN_CTRLMODE_BERR_REPORTING) {
++		u8 lec = FIELD_GET(PSR_LEC_MASK, psr);
++		u8 dlec = FIELD_GET(PSR_DLEC_MASK, psr);
++
++		if (is_lec_err(lec)) {
++			netdev_dbg(dev, "Arbitration phase error detected\n");
++			work_done += m_can_handle_lec_err(dev, lec);
++		}
++		
++		if (is_lec_err(dlec)) {
++			netdev_dbg(dev, "Data phase error detected\n");
++			work_done += m_can_handle_lec_err(dev, dlec);
++		}
++	}
+ 
+ 	/* handle protocol errors in arbitration phase */
+ 	if ((cdev->can.ctrlmode & CAN_CTRLMODE_BERR_REPORTING) &&
+@@ -902,14 +913,12 @@ static int m_can_handle_bus_errors(struct net_device *dev, u32 irqstatus,
+ 	return work_done;
+ }
+ 
+-static int m_can_rx_handler(struct net_device *dev, int quota)
++static int m_can_rx_handler(struct net_device *dev, int quota, u32 irqstatus)
+ {
+ 	struct m_can_classdev *cdev = netdev_priv(dev);
+ 	int rx_work_or_err;
+ 	int work_done = 0;
+-	u32 irqstatus, psr;
+ 
+-	irqstatus = cdev->irqstatus | m_can_read(cdev, M_CAN_IR);
+ 	if (!irqstatus)
+ 		goto end;
+ 
+@@ -934,13 +943,13 @@ static int m_can_rx_handler(struct net_device *dev, int quota)
+ 		}
+ 	}
+ 
+-	psr = m_can_read(cdev, M_CAN_PSR);
+-
+ 	if (irqstatus & IR_ERR_STATE)
+-		work_done += m_can_handle_state_errors(dev, psr);
++		work_done += m_can_handle_state_errors(dev,
++						       m_can_read(cdev, M_CAN_PSR));
+ 
+ 	if (irqstatus & IR_ERR_BUS_30X)
+-		work_done += m_can_handle_bus_errors(dev, irqstatus, psr);
++		work_done += m_can_handle_bus_errors(dev, irqstatus,
++						     m_can_read(cdev, M_CAN_PSR));
+ 
+ 	if (irqstatus & IR_RF0N) {
+ 		rx_work_or_err = m_can_do_rx_poll(dev, (quota - work_done));
+@@ -953,12 +962,12 @@ static int m_can_rx_handler(struct net_device *dev, int quota)
+ 	return work_done;
+ }
+ 
+-static int m_can_rx_peripheral(struct net_device *dev)
++static int m_can_rx_peripheral(struct net_device *dev, u32 irqstatus)
+ {
+ 	struct m_can_classdev *cdev = netdev_priv(dev);
+ 	int work_done;
+ 
+-	work_done = m_can_rx_handler(dev, M_CAN_NAPI_WEIGHT);
++	work_done = m_can_rx_handler(dev, NAPI_POLL_WEIGHT, irqstatus);
+ 
+ 	/* Don't re-enable interrupts if the driver had a fatal error
+ 	 * (e.g., FIFO read failure).
+@@ -974,8 +983,11 @@ static int m_can_poll(struct napi_struct *napi, int quota)
+ 	struct net_device *dev = napi->dev;
+ 	struct m_can_classdev *cdev = netdev_priv(dev);
+ 	int work_done;
++	u32 irqstatus;
+ 
+-	work_done = m_can_rx_handler(dev, quota);
++	irqstatus = cdev->irqstatus | m_can_read(cdev, M_CAN_IR);
++
++	work_done = m_can_rx_handler(dev, quota, irqstatus);
+ 
+ 	/* Don't re-enable interrupts if the driver had a fatal error
+ 	 * (e.g., FIFO read failure).
+@@ -1016,7 +1028,9 @@ static int m_can_echo_tx_event(struct net_device *dev)
+ 	u32 txe_count = 0;
+ 	u32 m_can_txefs;
+ 	u32 fgi = 0;
++	int ack_fgi = -1;
+ 	int i = 0;
++	int err = 0;
+ 	unsigned int msg_mark;
+ 
+ 	struct m_can_classdev *cdev = netdev_priv(dev);
+@@ -1026,34 +1040,34 @@ static int m_can_echo_tx_event(struct net_device *dev)
+ 
+ 	/* Get Tx Event fifo element count */
+ 	txe_count = FIELD_GET(TXEFS_EFFL_MASK, m_can_txefs);
++	fgi = FIELD_GET(TXEFS_EFGI_MASK, m_can_txefs);
+ 
+ 	/* Get and process all sent elements */
+ 	for (i = 0; i < txe_count; i++) {
+ 		u32 txe, timestamp = 0;
+-		int err;
+-
+-		/* retrieve get index */
+-		fgi = FIELD_GET(TXEFS_EFGI_MASK, m_can_read(cdev, M_CAN_TXEFS));
+ 
+ 		/* get message marker, timestamp */
+ 		err = m_can_txe_fifo_read(cdev, fgi, 4, &txe);
+ 		if (err) {
+ 			netdev_err(dev, "TXE FIFO read returned %d\n", err);
+-			return err;
++			break;
+ 		}
+ 
+ 		msg_mark = FIELD_GET(TX_EVENT_MM_MASK, txe);
+ 		timestamp = FIELD_GET(TX_EVENT_TXTS_MASK, txe) << 16;
+ 
+-		/* ack txe element */
+-		m_can_write(cdev, M_CAN_TXEFA, FIELD_PREP(TXEFA_EFAI_MASK,
+-							  fgi));
++		ack_fgi = fgi;
++		fgi = (++fgi >= cdev->mcfg[MRAM_TXE].num ? 0 : fgi);
+ 
+ 		/* update stats */
+ 		m_can_tx_update_stats(cdev, msg_mark, timestamp);
+ 	}
+ 
+-	return 0;
++	if (ack_fgi != -1)
++		m_can_write(cdev, M_CAN_TXEFA, FIELD_PREP(TXEFA_EFAI_MASK,
++							  ack_fgi));
++
++	return err;
+ }
+ 
+ static irqreturn_t m_can_isr(int irq, void *dev_id)
+@@ -1085,7 +1099,7 @@ static irqreturn_t m_can_isr(int irq, void *dev_id)
+ 		m_can_disable_all_interrupts(cdev);
+ 		if (!cdev->is_peripheral)
+ 			napi_schedule(&cdev->napi);
+-		else if (m_can_rx_peripheral(dev) < 0)
++		else if (m_can_rx_peripheral(dev, ir) < 0)
+ 			goto out_fail;
+ 	}
+ 
+@@ -1097,8 +1111,6 @@ static irqreturn_t m_can_isr(int irq, void *dev_id)
+ 			if (cdev->is_peripheral)
+ 				timestamp = m_can_get_timestamp(cdev);
+ 			m_can_tx_update_stats(cdev, 0, timestamp);
+-
+-			can_led_event(dev, CAN_LED_EVENT_TX);
+ 			netif_wake_queue(dev);
+ 		}
+ 	} else  {
+@@ -1107,7 +1119,6 @@ static irqreturn_t m_can_isr(int irq, void *dev_id)
+ 			if (m_can_echo_tx_event(dev) != 0)
+ 				goto out_fail;
+ 
+-			can_led_event(dev, CAN_LED_EVENT_TX);
+ 			if (netif_queue_stopped(dev) &&
+ 			    !m_can_tx_fifo_full(cdev))
+ 				netif_wake_queue(dev);
+@@ -1248,10 +1259,17 @@ static int m_can_set_bittiming(struct net_device *dev)
+  * - setup bittiming
+  * - configure timestamp generation
+  */
+-static void m_can_chip_config(struct net_device *dev)
++static int m_can_chip_config(struct net_device *dev)
+ {
+ 	struct m_can_classdev *cdev = netdev_priv(dev);
+ 	u32 cccr, test;
++	int err;
++
++	err = m_can_init_ram(cdev);
++	if (err) {
++		dev_err(cdev->dev, "Message RAM configuration failed\n");
++		return err;
++	}
+ 
+ 	m_can_config_endisable(cdev, true);
+ 
+@@ -1364,8 +1382,8 @@ static void m_can_chip_config(struct net_device *dev)
+ 	/* set bittiming params */
+ 	m_can_set_bittiming(dev);
+ 
+-	/* enable internal timestamp generation, with a prescalar of 16. The
+-	 * prescalar is applied to the nominal bit timing
++	/* enable internal timestamp generation, with a prescaler of 16. The
++	 * prescaler is applied to the nominal bit timing
+ 	 */
+ 	m_can_write(cdev, M_CAN_TSCC,
+ 		    FIELD_PREP(TSCC_TCP_MASK, 0xf) |
+@@ -1375,18 +1393,25 @@ static void m_can_chip_config(struct net_device *dev)
+ 
+ 	if (cdev->ops->init)
+ 		cdev->ops->init(cdev);
++
++	return 0;
+ }
+ 
+-static void m_can_start(struct net_device *dev)
++static int m_can_start(struct net_device *dev)
+ {
+ 	struct m_can_classdev *cdev = netdev_priv(dev);
++	int ret;
+ 
+ 	/* basic m_can configuration */
+-	m_can_chip_config(dev);
++	ret = m_can_chip_config(dev);
++	if (ret)
++		return ret;
+ 
+ 	cdev->can.state = CAN_STATE_ERROR_ACTIVE;
+ 
+ 	m_can_enable_all_interrupts(cdev);
++
++	return 0;
+ }
+ 
+ static int m_can_set_mode(struct net_device *dev, enum can_mode mode)
+@@ -1483,7 +1508,7 @@ static int m_can_dev_setup(struct m_can_classdev *cdev)
+ 
+ 	if (!cdev->is_peripheral)
+ 		netif_napi_add(dev, &cdev->napi,
+-			       m_can_poll, M_CAN_NAPI_WEIGHT);
++			       m_can_poll, NAPI_POLL_WEIGHT);
+ 
+ 	/* Shared properties of all M_CAN versions */
+ 	cdev->version = m_can_version;
+@@ -1502,32 +1527,20 @@ static int m_can_dev_setup(struct m_can_classdev *cdev)
+ 	case 30:
+ 		/* CAN_CTRLMODE_FD_NON_ISO is fixed with M_CAN IP v3.0.x */
+ 		can_set_static_ctrlmode(dev, CAN_CTRLMODE_FD_NON_ISO);
+-		cdev->can.bittiming_const = cdev->bit_timing ?
+-			cdev->bit_timing : &m_can_bittiming_const_30X;
+-
+-		cdev->can.data_bittiming_const = cdev->data_timing ?
+-			cdev->data_timing :
+-			&m_can_data_bittiming_const_30X;
++		cdev->can.bittiming_const = &m_can_bittiming_const_30X;
++		cdev->can.data_bittiming_const = &m_can_data_bittiming_const_30X;
+ 		break;
+ 	case 31:
+ 		/* CAN_CTRLMODE_FD_NON_ISO is fixed with M_CAN IP v3.1.x */
+ 		can_set_static_ctrlmode(dev, CAN_CTRLMODE_FD_NON_ISO);
+-		cdev->can.bittiming_const = cdev->bit_timing ?
+-			cdev->bit_timing : &m_can_bittiming_const_31X;
+-
+-		cdev->can.data_bittiming_const = cdev->data_timing ?
+-			cdev->data_timing :
+-			&m_can_data_bittiming_const_31X;
++		cdev->can.bittiming_const = &m_can_bittiming_const_31X;
++		cdev->can.data_bittiming_const = &m_can_data_bittiming_const_31X;
+ 		break;
+ 	case 32:
+ 	case 33:
+ 		/* Support both MCAN version v3.2.x and v3.3.0 */
+-		cdev->can.bittiming_const = cdev->bit_timing ?
+-			cdev->bit_timing : &m_can_bittiming_const_31X;
+-
+-		cdev->can.data_bittiming_const = cdev->data_timing ?
+-			cdev->data_timing :
+-			&m_can_data_bittiming_const_31X;
++		cdev->can.bittiming_const = &m_can_bittiming_const_31X;
++		cdev->can.data_bittiming_const = &m_can_data_bittiming_const_31X;
+ 
+ 		cdev->can.ctrlmode_supported |=
+ 			(m_can_niso_supported(cdev) ?
+@@ -1582,7 +1595,6 @@ static int m_can_close(struct net_device *dev)
+ 		can_rx_offload_disable(&cdev->offload);
+ 
+ 	close_candev(dev);
+-	can_led_event(dev, CAN_LED_EVENT_STOP);
+ 
+ 	phy_power_off(cdev->transceiver);
+ 
+@@ -1610,6 +1622,7 @@ static netdev_tx_t m_can_tx_handler(struct m_can_classdev *cdev)
+ 	struct sk_buff *skb = cdev->tx_skb;
+ 	struct id_and_dlc fifo_header;
+ 	u32 cccr, fdflags;
++	u32 txfqs;
+ 	int err;
+ 	int putidx;
+ 
+@@ -1666,8 +1679,10 @@ static netdev_tx_t m_can_tx_handler(struct m_can_classdev *cdev)
+ 	} else {
+ 		/* Transmit routine for version >= v3.1.x */
+ 
++		txfqs = m_can_read(cdev, M_CAN_TXFQS);
++
+ 		/* Check if FIFO full */
+-		if (m_can_tx_fifo_full(cdev)) {
++		if (_m_can_tx_fifo_full(txfqs)) {
+ 			/* This shouldn't happen */
+ 			netif_stop_queue(dev);
+ 			netdev_warn(dev,
+@@ -1683,8 +1698,7 @@ static netdev_tx_t m_can_tx_handler(struct m_can_classdev *cdev)
+ 		}
+ 
+ 		/* get put index for frame */
+-		putidx = FIELD_GET(TXFQS_TFQPI_MASK,
+-				   m_can_read(cdev, M_CAN_TXFQS));
++		putidx = FIELD_GET(TXFQS_TFQPI_MASK, txfqs);
+ 
+ 		/* Construct DLC Field, with CAN-FD configuration.
+ 		 * Use the put index of the fifo as the message marker,
+@@ -1824,9 +1838,9 @@ static int m_can_open(struct net_device *dev)
+ 	}
+ 
+ 	/* start the m_can controller */
+-	m_can_start(dev);
+-
+-	can_led_event(dev, CAN_LED_EVENT_OPEN);
++	err = m_can_start(dev);
++	if (err)
++		goto exit_irq_fail;
+ 
+ 	if (!cdev->is_peripheral)
+ 		napi_enable(&cdev->napi);
+@@ -1856,10 +1870,15 @@ static const struct net_device_ops m_can_netdev_ops = {
+ 	.ndo_change_mtu = can_change_mtu,
+ };
+ 
++static const struct ethtool_ops m_can_ethtool_ops = {
++	.get_ts_info = ethtool_op_get_ts_info,
++};
++
+ static int register_m_can_dev(struct net_device *dev)
+ {
+ 	dev->flags |= IFF_ECHO;	/* we support local echo */
+ 	dev->netdev_ops = &m_can_netdev_ops;
++	dev->ethtool_ops = &m_can_ethtool_ops;
+ 
+ 	return register_candev(dev);
+ }
+@@ -1931,7 +1950,7 @@ int m_can_class_get_clocks(struct m_can_classdev *cdev)
+ 	cdev->hclk = devm_clk_get(cdev->dev, "hclk");
+ 	cdev->cclk = devm_clk_get(cdev->dev, "cclk");
+ 
+-	if (IS_ERR(cdev->cclk)) {
++	if (IS_ERR(cdev->hclk) || IS_ERR(cdev->cclk)) {
+ 		dev_err(cdev->dev, "no clock found\n");
+ 		ret = -ENODEV;
+ 	}
+@@ -1999,7 +2018,7 @@ int m_can_class_register(struct m_can_classdev *cdev)
+ 
+ 	if (cdev->is_peripheral) {
+ 		ret = can_rx_offload_add_manual(cdev->net, &cdev->offload,
+-						M_CAN_NAPI_WEIGHT);
++						NAPI_POLL_WEIGHT);
+ 		if (ret)
+ 			goto clk_disable;
+ 	}
+@@ -2015,11 +2034,9 @@ int m_can_class_register(struct m_can_classdev *cdev)
+ 		goto rx_offload_del;
+ 	}
+ 
+-	devm_can_led_init(cdev->net);
+-
+ 	of_can_transceiver(cdev->net);
+ 
+-	dev_info(cdev->dev, "%s device registered (irq=%d, version=%d)\n",
++	dev_info(cdev->dev, "%s device registered(backported) (irq=%d, version=%d)\n",
+ 		 KBUILD_MODNAME, cdev->net->irq, cdev->version);
+ 
+ 	/* Probe finished
+@@ -2082,9 +2099,13 @@ int m_can_class_resume(struct device *dev)
+ 		ret = m_can_clk_start(cdev);
+ 		if (ret)
+ 			return ret;
++		ret  = m_can_start(ndev);
++		if (ret) {
++			m_can_clk_stop(cdev);
++
++			return ret;
++		}
+ 
+-		m_can_init_ram(cdev);
+-		m_can_start(ndev);
+ 		netif_device_attach(ndev);
+ 		netif_start_queue(ndev);
+ 	}
+diff --git a/drivers/net/can/m_can/m_can.h b/drivers/net/can/m_can/m_can.h
+index 2c5d40997168..a839dc71dc9b 100644
+--- a/drivers/net/can/m_can/m_can.h
++++ b/drivers/net/can/m_can/m_can.h
+@@ -7,28 +7,27 @@
+ #define _CAN_M_CAN_H_
+ 
+ #include <linux/can/core.h>
+-#include <linux/can/led.h>
++#include <linux/can/dev.h>
+ #include <linux/can/rx-offload.h>
++#include <linux/clk.h>
+ #include <linux/completion.h>
++#include <linux/delay.h>
+ #include <linux/device.h>
+ #include <linux/dma-mapping.h>
+ #include <linux/freezer.h>
+-#include <linux/slab.h>
+-#include <linux/uaccess.h>
+-#include <linux/clk.h>
+-#include <linux/delay.h>
+ #include <linux/interrupt.h>
+ #include <linux/io.h>
++#include <linux/iopoll.h>
+ #include <linux/kernel.h>
+ #include <linux/module.h>
+ #include <linux/netdevice.h>
+ #include <linux/of.h>
+ #include <linux/of_device.h>
+-#include <linux/pm_runtime.h>
+-#include <linux/iopoll.h>
+-#include <linux/can/dev.h>
+-#include <linux/pinctrl/consumer.h>
+ #include <linux/phy/phy.h>
++#include <linux/pinctrl/consumer.h>
++#include <linux/pm_runtime.h>
++#include <linux/slab.h>
++#include <linux/uaccess.h>
+ 
+ /* m_can lec values */
+ enum m_can_lec_type {
+@@ -39,7 +38,7 @@ enum m_can_lec_type {
+ 	LEC_BIT1_ERROR,
+ 	LEC_BIT0_ERROR,
+ 	LEC_CRC_ERROR,
+-	LEC_UNUSED,
++	LEC_NO_CHANGE,
+ };
+ 
+ enum m_can_mram_cfg {
+@@ -85,9 +84,6 @@ struct m_can_classdev {
+ 	struct sk_buff *tx_skb;
+ 	struct phy *transceiver;
+ 
+-	const struct can_bittiming_const *bit_timing;
+-	const struct can_bittiming_const *data_timing;
+-
+ 	struct m_can_ops *ops;
+ 
+ 	int version;
+diff --git a/drivers/net/can/m_can/m_can_pci.c b/drivers/net/can/m_can/m_can_pci.c
+index 8f184a852a0a..f2219aa2824b 100644
+--- a/drivers/net/can/m_can/m_can_pci.c
++++ b/drivers/net/can/m_can/m_can_pci.c
+@@ -120,7 +120,7 @@ static int m_can_pci_probe(struct pci_dev *pci, const struct pci_device_id *id)
+ 
+ 	ret = pci_alloc_irq_vectors(pci, 1, 1, PCI_IRQ_ALL_TYPES);
+ 	if (ret < 0)
+-		return ret;
++		goto err_free_dev;
+ 
+ 	mcan_class->dev = &pci->dev;
+ 	mcan_class->net->irq = pci_irq_vector(pci, 0);
+@@ -132,7 +132,7 @@ static int m_can_pci_probe(struct pci_dev *pci, const struct pci_device_id *id)
+ 
+ 	ret = m_can_class_register(mcan_class);
+ 	if (ret)
+-		goto err;
++		goto err_free_irq;
+ 
+ 	/* Enable interrupt control at CAN wrapper IP */
+ 	writel(0x1, base + CTL_CSR_INT_CTL_OFFSET);
+@@ -144,8 +144,10 @@ static int m_can_pci_probe(struct pci_dev *pci, const struct pci_device_id *id)
+ 
+ 	return 0;
+ 
+-err:
++err_free_irq:
+ 	pci_free_irq_vectors(pci);
++err_free_dev:
++	m_can_class_free_dev(mcan_class->net);
+ 	return ret;
+ }
+ 
+@@ -161,6 +163,7 @@ static void m_can_pci_remove(struct pci_dev *pci)
+ 	writel(0x0, priv->base + CTL_CSR_INT_CTL_OFFSET);
+ 
+ 	m_can_class_unregister(mcan_class);
++	m_can_class_free_dev(mcan_class->net);
+ 	pci_free_irq_vectors(pci);
+ }
+ 
+diff --git a/drivers/net/can/m_can/m_can_platform.c b/drivers/net/can/m_can/m_can_platform.c
+index eee47bad0592..9c1dcf838006 100644
+--- a/drivers/net/can/m_can/m_can_platform.c
++++ b/drivers/net/can/m_can/m_can_platform.c
+@@ -5,8 +5,8 @@
+ //
+ // Copyright (C) 2018-19 Texas Instruments Incorporated - http://www.ti.com/
+ 
+-#include <linux/platform_device.h>
+ #include <linux/phy/phy.h>
++#include <linux/platform_device.h>
+ 
+ #include "m_can.h"
+ 
+@@ -140,10 +140,6 @@ static int m_can_plat_probe(struct platform_device *pdev)
+ 
+ 	platform_set_drvdata(pdev, mcan_class);
+ 
+-	ret = m_can_init_ram(mcan_class);
+-	if (ret)
+-		goto probe_fail;
+-
+ 	pm_runtime_enable(mcan_class->dev);
+ 	ret = m_can_class_register(mcan_class);
+ 	if (ret)
+diff --git a/drivers/net/can/m_can/tcan4x5x-core.c b/drivers/net/can/m_can/tcan4x5x-core.c
+index 04687b15b250..9677562f3725 100644
+--- a/drivers/net/can/m_can/tcan4x5x-core.c
++++ b/drivers/net/can/m_can/tcan4x5x-core.c
+@@ -10,7 +10,7 @@
+ #define TCAN4X5X_DEV_ID1 0x04
+ #define TCAN4X5X_REV 0x08
+ #define TCAN4X5X_STATUS 0x0C
+-#define TCAN4X5X_ERROR_STATUS 0x10
++#define TCAN4X5X_ERROR_STATUS_MASK 0x10
+ #define TCAN4X5X_CONTROL 0x14
+ 
+ #define TCAN4X5X_CONFIG 0x800
+@@ -204,17 +204,7 @@ static int tcan4x5x_clear_interrupts(struct m_can_classdev *cdev)
+ 	if (ret)
+ 		return ret;
+ 
+-	ret = tcan4x5x_write_tcan_reg(cdev, TCAN4X5X_MCAN_INT_REG,
+-				      TCAN4X5X_ENABLE_MCAN_INT);
+-	if (ret)
+-		return ret;
+-
+-	ret = tcan4x5x_write_tcan_reg(cdev, TCAN4X5X_INT_FLAGS,
+-				      TCAN4X5X_CLEAR_ALL_INT);
+-	if (ret)
+-		return ret;
+-
+-	return tcan4x5x_write_tcan_reg(cdev, TCAN4X5X_ERROR_STATUS,
++	return tcan4x5x_write_tcan_reg(cdev, TCAN4X5X_INT_FLAGS,
+ 				       TCAN4X5X_CLEAR_ALL_INT);
+ }
+ 
+@@ -234,8 +224,8 @@ static int tcan4x5x_init(struct m_can_classdev *cdev)
+ 	if (ret)
+ 		return ret;
+ 
+-	/* Zero out the MCAN buffers */
+-	ret = m_can_init_ram(cdev);
++	ret = tcan4x5x_write_tcan_reg(cdev, TCAN4X5X_ERROR_STATUS_MASK,
++				      TCAN4X5X_CLEAR_ALL_INT);
+ 	if (ret)
+ 		return ret;
+ 
+@@ -378,7 +368,7 @@ static int tcan4x5x_can_probe(struct spi_device *spi)
+ 	if (ret)
+ 		goto out_power;
+ 
+-	netdev_info(mcan_class->net, "TCAN4X5X successfully initialized.\n");
++	netdev_info(mcan_class->net, "TCAN4X5X successfully initialized.\n");
+ 	return 0;
+ 
+ out_power:
+diff --git a/drivers/net/can/m_can/tcan4x5x-regmap.c b/drivers/net/can/m_can/tcan4x5x-regmap.c
+index 26e212b8ca7a..2b218ce04e9f 100644
+--- a/drivers/net/can/m_can/tcan4x5x-regmap.c
++++ b/drivers/net/can/m_can/tcan4x5x-regmap.c
+@@ -90,16 +90,47 @@ static int tcan4x5x_regmap_read(void *context,
+ 	return 0;
+ }
+ 
+-static const struct regmap_range tcan4x5x_reg_table_yes_range[] = {
+-	regmap_reg_range(0x0000, 0x002c),	/* Device ID and SPI Registers */
+-	regmap_reg_range(0x0800, 0x083c),	/* Device configuration registers and Interrupt Flags*/
++static const struct regmap_range tcan4x5x_reg_table_wr_range[] = {
++	/* Device ID and SPI Registers */
++	regmap_reg_range(0x000c, 0x0010),
++	/* Device configuration registers and Interrupt Flags*/
++	regmap_reg_range(0x0800, 0x080c),
++	regmap_reg_range(0x0814, 0x0814),
++	regmap_reg_range(0x0820, 0x0820),
++	regmap_reg_range(0x0830, 0x0830),
++	/* M_CAN */
++	regmap_reg_range(0x100c, 0x102c),
++	regmap_reg_range(0x1048, 0x1048),
++	regmap_reg_range(0x1050, 0x105c),
++	regmap_reg_range(0x1080, 0x1088),
++	regmap_reg_range(0x1090, 0x1090),
++	regmap_reg_range(0x1098, 0x10a0),
++	regmap_reg_range(0x10a8, 0x10b0),
++	regmap_reg_range(0x10b8, 0x10c0),
++	regmap_reg_range(0x10c8, 0x10c8),
++	regmap_reg_range(0x10d0, 0x10d4),
++	regmap_reg_range(0x10e0, 0x10e4),
++	regmap_reg_range(0x10f0, 0x10f0),
++	regmap_reg_range(0x10f8, 0x10f8),
++	/* MRAM */
++	regmap_reg_range(0x8000, 0x87fc),
++};
++
++static const struct regmap_range tcan4x5x_reg_table_rd_range[] = {
++	regmap_reg_range(0x0000, 0x0010),	/* Device ID and SPI Registers */
++	regmap_reg_range(0x0800, 0x0830),	/* Device configuration registers and Interrupt Flags*/
+ 	regmap_reg_range(0x1000, 0x10fc),	/* M_CAN */
+ 	regmap_reg_range(0x8000, 0x87fc),	/* MRAM */
+ };
+ 
+-static const struct regmap_access_table tcan4x5x_reg_table = {
+-	.yes_ranges = tcan4x5x_reg_table_yes_range,
+-	.n_yes_ranges = ARRAY_SIZE(tcan4x5x_reg_table_yes_range),
++static const struct regmap_access_table tcan4x5x_reg_table_wr = {
++	.yes_ranges = tcan4x5x_reg_table_wr_range,
++	.n_yes_ranges = ARRAY_SIZE(tcan4x5x_reg_table_wr_range),
++};
++
++static const struct regmap_access_table tcan4x5x_reg_table_rd = {
++	.yes_ranges = tcan4x5x_reg_table_rd_range,
++	.n_yes_ranges = ARRAY_SIZE(tcan4x5x_reg_table_rd_range),
+ };
+ 
+ static const struct regmap_config tcan4x5x_regmap = {
+@@ -107,8 +138,8 @@ static const struct regmap_config tcan4x5x_regmap = {
+ 	.reg_stride = 4,
+ 	.pad_bits = 8,
+ 	.val_bits = 32,
+-	.wr_table = &tcan4x5x_reg_table,
+-	.rd_table = &tcan4x5x_reg_table,
++	.wr_table = &tcan4x5x_reg_table_wr,
++	.rd_table = &tcan4x5x_reg_table_rd,
+ 	.max_register = TCAN4X5X_MAX_REGISTER,
+ 	.cache_type = REGCACHE_NONE,
+ 	.read_flag_mask = (__force unsigned long)
+-- 
+2.30.2
+

--- a/dynamic-layers/recipes-kernel/linux/linux-variscite/0021-HMX-Add-suspend-to-backported-m_can-driver.patch
+++ b/dynamic-layers/recipes-kernel/linux/linux-variscite/0021-HMX-Add-suspend-to-backported-m_can-driver.patch
@@ -1,0 +1,137 @@
+From ed7bf9c23a3501f20cb593635b9bf2cf876b6e5b Mon Sep 17 00:00:00 2001
+From: Mattias Busck <mattias.busck@hostmobility.com>
+Date: Thu, 23 Mar 2023 15:23:04 +0100
+Subject: [PATCH] HMX:Add suspend to backported m_can driver
+
+v1. Requires an ip link set canX down; ip link set canX up toggle to get
+traffic after sleep
+v2. Since the HMX has one wakeup-line for all the CAN controllers, we
+need to make the wakeup gpio line global. TODO: clean this up
+---
+ drivers/net/can/m_can/m_can.c         |  2 +-
+ drivers/net/can/m_can/tcan4x5x-core.c | 81 +++++++++++++++++++++++++--
+ 2 files changed, 76 insertions(+), 7 deletions(-)
+
+diff --git a/drivers/net/can/m_can/tcan4x5x-core.c b/drivers/net/can/m_can/tcan4x5x-core.c
+index 9677562f3725..02b46386c5a4 100644
+--- a/drivers/net/can/m_can/tcan4x5x-core.c
++++ b/drivers/net/can/m_can/tcan4x5x-core.c
+@@ -253,20 +253,30 @@ static int tcan4x5x_disable_state(struct m_can_classdev *cdev)
+ 				  TCAN4X5X_DISABLE_INH_MSK, 0x01);
+ }
+ 
++static struct gpio_desc *global_device_wake_gpio = NULL;
++
+ static int tcan4x5x_get_gpios(struct m_can_classdev *cdev)
+ {
+ 	struct tcan4x5x_priv *tcan4x5x = cdev_to_priv(cdev);
+ 	int ret;
+ 
+-	tcan4x5x->device_wake_gpio = devm_gpiod_get(cdev->dev, "device-wake",
++
++	if (!global_device_wake_gpio) {
++		global_device_wake_gpio = devm_gpiod_get(cdev->dev, "device-wake",
+ 						    GPIOD_OUT_HIGH);
+-	if (IS_ERR(tcan4x5x->device_wake_gpio)) {
+-		if (PTR_ERR(tcan4x5x->device_wake_gpio) == -EPROBE_DEFER)
++		dev_info(cdev->dev, "global_device_wake_gpio=%pB\n", global_device_wake_gpio);
++	}
++
++	if (IS_ERR(global_device_wake_gpio)) {
++		if (PTR_ERR(global_device_wake_gpio) == -EPROBE_DEFER)
+ 			return -EPROBE_DEFER;
+ 
+-		tcan4x5x_disable_wake(cdev);
++		global_device_wake_gpio = NULL;
++		dev_warn(cdev->dev, "disabling wake\n");
++		//tcan4x5x_disable_wake(cdev);
+ 	}
+ 
++
+ 	tcan4x5x->reset_gpio = devm_gpiod_get_optional(cdev->dev, "reset",
+ 						       GPIOD_OUT_LOW);
+ 	if (IS_ERR(tcan4x5x->reset_gpio))
+@@ -368,7 +378,7 @@ static int tcan4x5x_can_probe(struct spi_device *spi)
+ 	if (ret)
+ 		goto out_power;
+ 
+-	netdev_info(mcan_class->net, "TCAN4X5X successfully initialized.\n");
++	netdev_info(mcan_class->net, "TCAN4X5X successfully initialized.\n");
+ 	return 0;
+ 
+ out_power:
+@@ -409,11 +419,70 @@ static const struct spi_device_id tcan4x5x_id_table[] = {
+ };
+ MODULE_DEVICE_TABLE(spi, tcan4x5x_id_table);
+ 
++static int __maybe_unused tcan4x5x_suspend(struct device *dev)
++{
++	int ret;
++	struct spi_device *spi = to_spi_device(dev);
++	struct tcan4x5x_priv *priv = spi_get_drvdata(spi);
++	struct net_device *net = (priv->cdev).net;
++
++	
++
++	disable_irq(spi->irq);
++	/* Note: at this point neither IST nor workqueues are running.
++	 * open/stop cannot be called anyway so locking is not needed
++	 */
++	if (netif_running(net)) {
++		dev_info(dev, "Disabled irq Entering sleep(%d), enabling wake on 0x%x\n", ret, spi->irq);
++		m_can_class_suspend(dev);
++		ret = regmap_update_bits(priv->regmap, TCAN4X5X_CONFIG,
++				 TCAN4X5X_MODE_SEL_MASK, TCAN4X5X_MODE_SLEEP);
++		enable_irq_wake(spi->irq);
++		//tcan4x5x_hw_sleep(spi);
++		//netif_stop_queue(net);
++		//netif_device_detach(net);
++	} else {
++		dev_info(dev, "Entering suspend, interface is down, no wake\n");
++		m_can_class_suspend(dev);
++	}
++
++
++	return 0;
++}
++
++static int __maybe_unused tcan4x5x_resume(struct device *dev)
++{
++	int ret;
++	struct spi_device *spi = to_spi_device(dev);
++	struct tcan4x5x_priv *priv = spi_get_drvdata(spi);
++	struct net_device *net = (priv->cdev).net;
++
++
++	if (global_device_wake_gpio) {
++		dev_info(dev, "RESUME WAKE UP using %pB \n", global_device_wake_gpio);
++		gpiod_set_value(global_device_wake_gpio, 0);
++		usleep_range(5000, 50000);
++		gpiod_set_value(global_device_wake_gpio, 1);
++	} else {
++		dev_warn(dev, "NO WaKE UP DEFINED %pB \n", global_device_wake_gpio);
++	}
++	
++	
++	ret = regmap_update_bits(priv->regmap, TCAN4X5X_CONFIG,
++				 TCAN4X5X_MODE_SEL_MASK, TCAN4X5X_MODE_NORMAL);
++
++	m_can_class_resume(dev);
++	return 0;
++}
++
++static SIMPLE_DEV_PM_OPS(tcan4x5x_pm_ops, tcan4x5x_suspend,
++	tcan4x5x_resume);
++
+ static struct spi_driver tcan4x5x_can_driver = {
+ 	.driver = {
+ 		.name = KBUILD_MODNAME,
+ 		.of_match_table = tcan4x5x_of_match,
+-		.pm = NULL,
++		.pm = &tcan4x5x_pm_ops,
+ 	},
+ 	.id_table = tcan4x5x_id_table,
+ 	.probe = tcan4x5x_can_probe,
+-- 
+2.30.2
+

--- a/dynamic-layers/recipes-kernel/linux/linux-variscite/0026-HMX-m_can-do-not-init-registers-until-bus-on.patch
+++ b/dynamic-layers/recipes-kernel/linux/linux-variscite/0026-HMX-m_can-do-not-init-registers-until-bus-on.patch
@@ -1,0 +1,177 @@
+From db22888e32d715fdafe82aa094a223d62cf63180 Mon Sep 17 00:00:00 2001
+From: Mattias Busck <mattias.busck@hostmobility.com>
+Date: Wed, 12 Apr 2023 18:00:05 +0200
+Subject: [PATCH 26/27] HMX: m_can do not init registers until bus-on
+
+Initializing registers before bus-on results in error-frames. We only
+need to do the necessary initialization to prevent sleep(TODO)
+---
+ drivers/net/can/m_can/m_can.c         | 11 +++++--
+ drivers/net/can/m_can/tcan4x5x-core.c | 45 +++++++++++++++++++++++----
+ 2 files changed, 47 insertions(+), 9 deletions(-)
+
+diff --git a/drivers/net/can/m_can/m_can.c b/drivers/net/can/m_can/m_can.c
+index a7c27fb6dd37..c0b47708e8fe 100644
+--- a/drivers/net/can/m_can/m_can.c
++++ b/drivers/net/can/m_can/m_can.c
+@@ -1524,6 +1524,7 @@ static int m_can_dev_setup(struct m_can_classdev *cdev)
+ 		CAN_CTRLMODE_ONE_SHOT;
+ 
+ 	/* Set properties depending on M_CAN version */
++	dev_err(cdev->dev, "set properties for cdev-version %d", cdev->version);
+ 	switch (cdev->version) {
+ 	case 30:
+ 		/* CAN_CTRLMODE_FD_NON_ISO is fixed with M_CAN IP v3.0.x */
+@@ -1543,9 +1544,11 @@ static int m_can_dev_setup(struct m_can_classdev *cdev)
+ 		cdev->can.bittiming_const = &m_can_bittiming_const_31X;
+ 		cdev->can.data_bittiming_const = &m_can_data_bittiming_const_31X;
+ 
++		/*
+ 		cdev->can.ctrlmode_supported |=
+ 			(m_can_niso_supported(cdev) ?
+ 			 CAN_CTRLMODE_FD_NON_ISO : 0);
++			 */
+ 		break;
+ 	default:
+ 		dev_err(cdev->dev, "Unsupported version number: %2d",
+@@ -1553,8 +1556,10 @@ static int m_can_dev_setup(struct m_can_classdev *cdev)
+ 		return -EINVAL;
+ 	}
+ 
+-	if (cdev->ops->init)
+-		cdev->ops->init(cdev);
++	
++	dev_err(cdev->dev, "NISO!: %2d", 45);
++	//TODO dev_setupt should not init if (cdev->ops->init)
++//		cdev->ops->init(cdev);
+ 
+ 	return 0;
+ }
+diff --git a/drivers/net/can/m_can/tcan4x5x-core.c b/drivers/net/can/m_can/tcan4x5x-core.c
+index 02b46386c5a4..2620e06c2389 100644
+--- a/drivers/net/can/m_can/tcan4x5x-core.c
++++ b/drivers/net/can/m_can/tcan4x5x-core.c
+@@ -124,6 +124,7 @@ static void tcan4x5x_check_wake(struct tcan4x5x_priv *priv)
+ static int tcan4x5x_reset(struct tcan4x5x_priv *priv)
+ {
+ 	int ret = 0;
++	//return 0;
+ 
+ 	if (priv->reset_gpio) {
+ 		gpiod_set_value(priv->reset_gpio, 1);
+@@ -132,13 +133,15 @@ static int tcan4x5x_reset(struct tcan4x5x_priv *priv)
+ 		usleep_range(30, 100);
+ 		gpiod_set_value(priv->reset_gpio, 0);
+ 	} else {
++	usleep_range(40000, 41000);
++		dev_err(priv->cdev.dev, "SOFTWARE RESETS\n");
+ 		ret = regmap_write(priv->regmap, TCAN4X5X_CONFIG,
+ 				   TCAN4X5X_SW_RESET);
+ 		if (ret)
+ 			return ret;
+ 	}
+ 
+-	usleep_range(700, 1000);
++	usleep_range(40000, 41000);
+ 
+ 	return ret;
+ }
+@@ -164,6 +167,7 @@ static int tcan4x5x_read_fifo(struct m_can_classdev *cdev, int addr_offset,
+ static int tcan4x5x_write_reg(struct m_can_classdev *cdev, int reg, int val)
+ {
+ 	struct tcan4x5x_priv *priv = cdev_to_priv(cdev);
++	//dev_err(cdev->dev, "writing mcan reg 0x%x(0x%x) ras 0x%x\n", reg, reg + TCAN4X5X_MCAN_OFFSET, val);
+ 
+ 	return regmap_write(priv->regmap, TCAN4X5X_MCAN_OFFSET + reg, val);
+ }
+@@ -192,6 +196,7 @@ static int tcan4x5x_write_tcan_reg(struct m_can_classdev *cdev,
+ {
+ 	struct tcan4x5x_priv *priv = cdev_to_priv(cdev);
+ 
++	//dev_err(cdev->dev, "writing tcan reg 0x%x ras 0x%x\n", reg, val);
+ 	return regmap_write(priv->regmap, reg, val);
+ }
+ 
+@@ -370,15 +375,16 @@ static int tcan4x5x_can_probe(struct spi_device *spi)
+ 	if (ret)
+ 		goto out_power;
+ 
+-	ret = tcan4x5x_init(mcan_class);
+-	if (ret)
+-		goto out_power;
++
++	//TODO probe shall not calll init ret = tcan4x5x_init(mcan_class);
++	//if (ret)
++//		goto out_power;
+ 
+ 	ret = m_can_class_register(mcan_class);
+ 	if (ret)
+ 		goto out_power;
+ 
+-	netdev_info(mcan_class->net, "TCAN4X5X successfully initialized.\n");
++	netdev_info(mcan_class->net, "TCAN4X5X successfully initialized.\n");
+ 	return 0;
+ 
+ out_power:
+@@ -443,6 +449,8 @@ static int __maybe_unused tcan4x5x_suspend(struct device *dev)
+ 		//netif_device_detach(net);
+ 	} else {
+ 		dev_info(dev, "Entering suspend, interface is down, no wake\n");
++		ret = regmap_update_bits(priv->regmap, TCAN4X5X_CONFIG,
++				 TCAN4X5X_MODE_SEL_MASK, TCAN4X5X_MODE_SLEEP);
+ 		m_can_class_suspend(dev);
+ 	}
+ 
+@@ -455,7 +463,7 @@ static int __maybe_unused tcan4x5x_resume(struct device *dev)
+ 	int ret;
+ 	struct spi_device *spi = to_spi_device(dev);
+ 	struct tcan4x5x_priv *priv = spi_get_drvdata(spi);
+-	struct net_device *net = (priv->cdev).net;
++	//unstruct net_device *net = (priv->cdev).net;
+ 
+ 
+ 	if (global_device_wake_gpio) {
+@@ -475,8 +483,32 @@ static int __maybe_unused tcan4x5x_resume(struct device *dev)
+ 	return 0;
+ }
+ 
++static int __maybe_unused tcan4x5x_poweroff(struct device *dev)
++{
++	int ret;
++	struct spi_device *spi = to_spi_device(dev);
++	struct tcan4x5x_priv *priv = spi_get_drvdata(spi);
++	struct net_device *net = (priv->cdev).net;
++
++	
++
++	disable_irq(spi->irq);
++	ret = regmap_update_bits(priv->regmap, TCAN4X5X_CONFIG,
++				 TCAN4X5X_MODE_SEL_MASK, TCAN4X5X_MODE_SLEEP);
++
++	return 0;
++}
++
++/*
+ static SIMPLE_DEV_PM_OPS(tcan4x5x_pm_ops, tcan4x5x_suspend,
+ 	tcan4x5x_resume);
++	*/
++
++static struct dev_pm_ops tcan4x5x_pm_ops = {
++	.suspend = tcan4x5x_suspend,
++	.resume = tcan4x5x_resume,
++	.poweroff = tcan4x5x_poweroff
++};
+ 
+ static struct spi_driver tcan4x5x_can_driver = {
+ 	.driver = {
+@@ -488,6 +520,7 @@ static struct spi_driver tcan4x5x_can_driver = {
+ 	.probe = tcan4x5x_can_probe,
+ 	.remove = tcan4x5x_can_remove,
+ };
++
+ module_spi_driver(tcan4x5x_can_driver);
+ 
+ MODULE_AUTHOR("Dan Murphy <dmurphy@ti.com>");
+-- 
+2.30.2
+

--- a/dynamic-layers/recipes-kernel/linux/linux-variscite/0027-tcan4x5x-add-direct-register-read-debug.patch
+++ b/dynamic-layers/recipes-kernel/linux/linux-variscite/0027-tcan4x5x-add-direct-register-read-debug.patch
@@ -1,0 +1,146 @@
+From e50fb59f239d3ea3b192d9502da49c764eaabccb Mon Sep 17 00:00:00 2001
+From: Mattias Busck <mattias.busck@hostmobility.com>
+Date: Wed, 7 Jun 2023 17:05:15 +0200
+Subject: [PATCH] tcan4x5x: add direct register read debug
+
+usage example:
+
+trap finish INT
+
+finish()
+{
+    echo "--- result ---"
+    for key in "${!changing[@]}"; do
+        if (( changing[$key] != 1 )); then
+            echo "${p[$key]} changed ${changing[$key]} times"
+        fi
+    done
+    exit 0
+}
+
+regs="0 4 8 c 10 800 804 808 80c 820 824 830 1000 1004 1008 100c 1010 1014 1018 101c 1020 1024 1028 102c 1040 1044 1048 1050 1054 1058 105c 1080 1084 1088 1090 1094 1098 109c 10a0 10a4 10a8 10ac 10b0 10b4 10b8 10bc 10c0 10c4 10c8 10cc 10d0"
+
+value_file=/sys/class/net/can0/device/debug_register
+address_file=/sys/class/net/can0/device/debug_register_address
+
+declare -A changing
+declare -A p
+while true; do
+    for reg in $regs; do
+        if [[ $reg == "1024" ]]; then continue; fi
+        echo "$reg" > $address_file
+        read -r val < $value_file
+        if [[ $val != "${p[$reg]}" ]]; then
+            echo "$val" >> /tmp/reg_"$reg"
+            ((changing[$reg]++ == 1))
+            #if ((changing[$reg] == 1)); then
+                date +"%H:%M:%S new value for register $reg was ${p[$reg]}"
+            #fi
+            p[$reg]=$val
+        fi
+    done
+done
+---
+ drivers/net/can/m_can/tcan4x5x-core.c | 59 +++++++++++++++++++++++++++
+ drivers/net/can/m_can/tcan4x5x.h      |  1 +
+ 2 files changed, 60 insertions(+)
+
+diff --git a/drivers/net/can/m_can/tcan4x5x-core.c b/drivers/net/can/m_can/tcan4x5x-core.c
+index 53e6010045df..e77c37581c83 100644
+--- a/drivers/net/can/m_can/tcan4x5x-core.c
++++ b/drivers/net/can/m_can/tcan4x5x-core.c
+@@ -311,6 +311,62 @@ static struct m_can_ops tcan4x5x_ops = {
+ 	.clear_interrupts = tcan4x5x_clear_interrupts,
+ };
+ 
++static ssize_t select_debug_register(struct device *dev, struct device_attribute *attr, const char *buf, size_t count)
++{
++	/* Select register with hexadecimal value without 0x prefix */
++	struct tcan4x5x_priv *priv = dev_get_drvdata(dev);
++	int scan_result = sscanf(buf, "%X", &priv->tcan4x5x_debug_register_address);  
++	return scan_result == 1 ? count : 0;
++}
++
++static ssize_t get_debug_register(struct device *dev, struct device_attribute *attr, char *buf)
++{
++	int count;
++	int val;
++	struct tcan4x5x_priv *priv = dev_get_drvdata(dev);
++	if (regmap_read(priv->regmap, priv->tcan4x5x_debug_register_address, &val))
++		return 0;
++
++	count = sprintf(buf, "%X", val);
++	return count;
++}
++
++
++static ssize_t set_debug_register(struct device *dev, struct device_attribute *attr, const char *buf, size_t count)
++{
++	struct tcan4x5x_priv *priv = dev_get_drvdata(dev);
++	int val;
++
++	sscanf(buf, "%X", &val);  
++	netdev_warn(priv->cdev.net, "setting %x to %x",priv->tcan4x5x_debug_register_address,val );
++	return regmap_write(priv->regmap, priv->tcan4x5x_debug_register_address, val) ? 0 : count;
++}
++
++static ssize_t nudge(struct device *dev, struct device_attribute *attr, const char * buf, size_t count)
++{
++	struct tcan4x5x_priv *priv = dev_get_drvdata(dev);
++
++	netif_wake_queue(priv->cdev.net);
++	netdev_warn(priv->cdev.net, "nudging");
++	return count;
++}
++
++static DEVICE_ATTR(debug_register_address, S_IWUSR | S_IRUGO, NULL, select_debug_register);
++static DEVICE_ATTR(debug_register, S_IWUSR | S_IRUGO, get_debug_register, set_debug_register);
++static DEVICE_ATTR(nudge, S_IWUSR | S_IRUGO, NULL, nudge);
++
++static struct attribute *tcan4x5x_attributes[] = {
++	&dev_attr_debug_register_address.attr,
++	&dev_attr_debug_register.attr,
++	&dev_attr_nudge.attr,
++	NULL
++};
++
++static const struct attribute_group  tcan4x5x_attribute_group = {
++	.attrs = tcan4x5x_attributes
++};
++
++
+ static int tcan4x5x_can_probe(struct spi_device *spi)
+ {
+ 	struct tcan4x5x_priv *priv;
+@@ -384,6 +440,7 @@ static int tcan4x5x_can_probe(struct spi_device *spi)
+ 	if (ret)
+ 		goto out_power;
+ 
++	sysfs_create_group(&spi->dev.kobj, &tcan4x5x_attribute_group);
+ 	netdev_info(mcan_class->net, "TCAN4X5X successfully initialized.\n");
+ 	return 0;
+ 
+@@ -402,6 +459,8 @@ static int tcan4x5x_can_remove(struct spi_device *spi)
+ 
+ 	tcan4x5x_power_enable(priv->power, 0);
+ 
++	sysfs_remove_group(&spi->dev.kobj, &tcan4x5x_attribute_group);
++
+ 	m_can_class_free_dev(priv->cdev.net);
+ 
+ 	return 0;
+diff --git a/drivers/net/can/m_can/tcan4x5x.h b/drivers/net/can/m_can/tcan4x5x.h
+index e62c030d3e1e..772fda831c87 100644
+--- a/drivers/net/can/m_can/tcan4x5x.h
++++ b/drivers/net/can/m_can/tcan4x5x.h
+@@ -42,6 +42,7 @@ struct tcan4x5x_priv {
+ 
+ 	struct tcan4x5x_map_buf map_buf_rx;
+ 	struct tcan4x5x_map_buf map_buf_tx;
++	int tcan4x5x_debug_register_address;
+ };
+ 
+ static inline void
+-- 
+2.30.2
+

--- a/dynamic-layers/recipes-kernel/linux/linux-variscite/0028-tcan4x4-stop-queue-first-in-transmit-to-avoid-race.patch
+++ b/dynamic-layers/recipes-kernel/linux/linux-variscite/0028-tcan4x4-stop-queue-first-in-transmit-to-avoid-race.patch
@@ -1,0 +1,36 @@
+From 059626cd9c525ac715ab73cce2d9b3e2ecc7ce53 Mon Sep 17 00:00:00 2001
+From: Mattias Busck <mattias.busck@hostmobility.com>
+Date: Tue, 30 May 2023 15:11:34 +0200
+Subject: [PATCH 4/4] tcan4x4 stop queue first in transmit to avoid race
+
+---
+ drivers/net/can/m_can/m_can.c | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/drivers/net/can/m_can/m_can.c b/drivers/net/can/m_can/m_can.c
+index d3f29ab2142a..c20b64906352 100644
+--- a/drivers/net/can/m_can/m_can.c
++++ b/drivers/net/can/m_can/m_can.c
+@@ -1680,6 +1680,7 @@ static netdev_tx_t m_can_tx_handler(struct m_can_classdev *cdev)
+ 	} else {
+ 		/* Transmit routine for version >= v3.1.x */
+ 
++		netif_stop_queue(dev);
+ 		txfqs = m_can_read(cdev, M_CAN_TXFQS);
+ 
+ 		/* Check if FIFO full */
+@@ -1735,9 +1736,8 @@ static netdev_tx_t m_can_tx_handler(struct m_can_classdev *cdev)
+ 		m_can_write(cdev, M_CAN_TXBAR, (1 << putidx));
+ 
+ 		/* stop network queue if fifo full */
+-		if (m_can_tx_fifo_full(cdev) ||
+-		    m_can_next_echo_skb_occupied(dev, putidx))
+-			netif_stop_queue(dev);
++		//if (m_can_tx_fifo_full(cdev) ||
++		    //m_can_next_echo_skb_occupied(dev, putidx))
+ 	}
+ 
+ 	return NETDEV_TX_OK;
+-- 
+2.30.2
+

--- a/dynamic-layers/recipes-kernel/linux/linux-variscite/0029-tcan4x5x-remove-msg-lost-netdev_err-print.patch
+++ b/dynamic-layers/recipes-kernel/linux/linux-variscite/0029-tcan4x5x-remove-msg-lost-netdev_err-print.patch
@@ -1,0 +1,25 @@
+From b1944e2c8c7fcf89e585f336a884706a9d0520c2 Mon Sep 17 00:00:00 2001
+From: Mattias Busck <mattias.busck@hostmobility.com>
+Date: Tue, 30 May 2023 15:10:17 +0200
+Subject: [PATCH 3/3] tcan4x5x: remove msg lost netdev_err print
+
+---
+ drivers/net/can/m_can/m_can.c | 2 --
+ 1 file changed, 2 deletions(-)
+
+diff --git a/drivers/net/can/m_can/m_can.c b/drivers/net/can/m_can/m_can.c
+index 8e83d6963d85..d3f29ab2142a 100644
+--- a/drivers/net/can/m_can/m_can.c
++++ b/drivers/net/can/m_can/m_can.c
+@@ -591,8 +591,6 @@ static int m_can_handle_lost_msg(struct net_device *dev)
+ 	struct can_frame *frame;
+ 	u32 timestamp = 0;
+ 
+-	netdev_err(dev, "msg lost in rxf0\n");
+-
+ 	stats->rx_errors++;
+ 	stats->rx_over_errors++;
+ 
+-- 
+2.30.2
+

--- a/dynamic-layers/recipes-kernel/linux/linux-variscite_%.bbappend
+++ b/dynamic-layers/recipes-kernel/linux/linux-variscite_%.bbappend
@@ -6,13 +6,10 @@ SRC_URI += "\
 file://0001-add-hmx-device-tree.patch \
 file://0002-Set-I2C1-for-imx8mp-var-dart.dtsi-to-lower-clock-fre.patch \
 file://0001-TCAN114x-driver-with-normal-standby-sleep-mode.patch \
-file://0016-improve-tcan4x5x-spi-performance.-coalesce-irqs.patch \
-file://0017-Add-suspend-to-optimized-tcan4x5x-driver.patch \
 file://0018-power-reset-gpio-poweroff-add-force-mode.patch  \
 file://0022-gpio-keys-make-disabled-keys-not-wake-system.patch  \
+file://0020-HMX-backport-m_can-from-linux-can-next.patch  \
 "
-# file://0011-Add-control-for-selective-wakeup.patch
-# file://0008-Add-suspend-to-tcan4x5x-driver.patch 
 
 SRC_URI += "file://defconfig"
 

--- a/dynamic-layers/recipes-kernel/linux/linux-variscite_%.bbappend
+++ b/dynamic-layers/recipes-kernel/linux/linux-variscite_%.bbappend
@@ -12,6 +12,7 @@ file://0020-HMX-backport-m_can-from-linux-can-next.patch  \
 file://0021-HMX-Add-suspend-to-backported-m_can-driver.patch \
 file://0026-HMX-m_can-do-not-init-registers-until-bus-on.patch \
 file://0027-tcan4x5x-add-direct-register-read-debug.patch \
+file://0028-tcan4x4-stop-queue-first-in-transmit-to-avoid-race.patch \
 "
 
 SRC_URI += "file://defconfig"

--- a/dynamic-layers/recipes-kernel/linux/linux-variscite_%.bbappend
+++ b/dynamic-layers/recipes-kernel/linux/linux-variscite_%.bbappend
@@ -10,6 +10,7 @@ file://0018-power-reset-gpio-poweroff-add-force-mode.patch  \
 file://0022-gpio-keys-make-disabled-keys-not-wake-system.patch  \
 file://0020-HMX-backport-m_can-from-linux-can-next.patch  \
 file://0021-HMX-Add-suspend-to-backported-m_can-driver.patch \
+file://0026-HMX-m_can-do-not-init-registers-until-bus-on.patch \
 "
 
 SRC_URI += "file://defconfig"

--- a/dynamic-layers/recipes-kernel/linux/linux-variscite_%.bbappend
+++ b/dynamic-layers/recipes-kernel/linux/linux-variscite_%.bbappend
@@ -11,6 +11,7 @@ file://0022-gpio-keys-make-disabled-keys-not-wake-system.patch  \
 file://0020-HMX-backport-m_can-from-linux-can-next.patch  \
 file://0021-HMX-Add-suspend-to-backported-m_can-driver.patch \
 file://0026-HMX-m_can-do-not-init-registers-until-bus-on.patch \
+file://0027-tcan4x5x-add-direct-register-read-debug.patch \
 "
 
 SRC_URI += "file://defconfig"

--- a/dynamic-layers/recipes-kernel/linux/linux-variscite_%.bbappend
+++ b/dynamic-layers/recipes-kernel/linux/linux-variscite_%.bbappend
@@ -13,6 +13,7 @@ file://0021-HMX-Add-suspend-to-backported-m_can-driver.patch \
 file://0026-HMX-m_can-do-not-init-registers-until-bus-on.patch \
 file://0027-tcan4x5x-add-direct-register-read-debug.patch \
 file://0028-tcan4x4-stop-queue-first-in-transmit-to-avoid-race.patch \
+file://0029-tcan4x5x-remove-msg-lost-netdev_err-print.patch \
 "
 
 SRC_URI += "file://defconfig"

--- a/dynamic-layers/recipes-kernel/linux/linux-variscite_%.bbappend
+++ b/dynamic-layers/recipes-kernel/linux/linux-variscite_%.bbappend
@@ -9,6 +9,7 @@ file://0001-TCAN114x-driver-with-normal-standby-sleep-mode.patch \
 file://0018-power-reset-gpio-poweroff-add-force-mode.patch  \
 file://0022-gpio-keys-make-disabled-keys-not-wake-system.patch  \
 file://0020-HMX-backport-m_can-from-linux-can-next.patch  \
+file://0021-HMX-Add-suspend-to-backported-m_can-driver.patch \
 "
 
 SRC_URI += "file://defconfig"


### PR DESCRIPTION
tcan4x5x driver backported from linux-can-next repo with added suspend, register init wait to prevent errorframes and race condition fix.

Some cosmetic debug prints and commented out code to be cleaned up