### PR TITLE
hmx:Do not install networkmanager

### DIFF
--- a/conf/machine/include/hmx-base.conf
+++ b/conf/machine/include/hmx-base.conf
@@ -11,6 +11,7 @@ meta-hostmobility-bsp/recipes-bsp/libubootenv \
 meta-mobility-poky-distro/recipes-connectivity/networkmanager/networkmanager_%.bbappend \
 "
 
+PREFERRED_CONNECTIVITY_MANAGER_PACKAGES = ""
 IMAGE_INSTALL:append = " \
     flash-script \
     hm-autostart \ 


### PR DESCRIPTION
NetworkManager is installed due to
PREFERRED_CONNECTIVITY_MANAGER_PACKAGES
being set in meta-variscite-bsp/conf/machine/variscite.inc Set this to nothing instead.