### PR TITLE
C61:V61: Fix Gpio names for co-cpu

### DIFF
--- a/recipes-kernel/linux/linux-hostmobility-vf/mx4-c61/0001-add-device-tree-for-c61-v61.patch
+++ b/recipes-kernel/linux/linux-hostmobility-vf/mx4-c61/0001-add-device-tree-for-c61-v61.patch
@@ -1,16 +1,16 @@
-From d214b09fb4f2ebe06fa9346b521b7018c3227bbf Mon Sep 17 00:00:00 2001
+From 170c2c52858a98e033946f8f7ec4f6aa7e1bcd15 Mon Sep 17 00:00:00 2001
 From: rikardo <rikard.olander@hostmobility.com>
-Date: Fri, 2 Sep 2022 10:43:51 +0000
-Subject: [PATCH] add-device-tree-for-c61-v61
+Date: Fri, 9 Jun 2023 14:35:52 +0000
+Subject: [PATCH 1/1] add-device-tree-for-c61-v61
 
 ---
- arch/arm/boot/dts/vf-mx4-c61.dtsi   | 201 ++++++++++++++++++++
- arch/arm/boot/dts/vf-mx4-v61.dtsi   | 184 +++++++++++++++++++
+ arch/arm/boot/dts/vf-mx4-c61.dtsi   | 259 ++++++++++++++++++++++++++
+ arch/arm/boot/dts/vf-mx4-v61.dtsi   | 242 ++++++++++++++++++++++++
  arch/arm/boot/dts/vf-mx4.dtsi       | 274 ++++++++++++++++++++++++++++
  arch/arm/boot/dts/vf610-mx4-c61.dts |  17 ++
  arch/arm/boot/dts/vf610-mx4-v61.dts |  22 +++
- arch/arm/boot/dts/vf610-mx4.dtsi    | 104 +++++++++++
- 6 files changed, 802 insertions(+)
+ arch/arm/boot/dts/vf610-mx4.dtsi    | 103 +++++++++++
+ 6 files changed, 917 insertions(+)
  create mode 100644 arch/arm/boot/dts/vf-mx4-c61.dtsi
  create mode 100644 arch/arm/boot/dts/vf-mx4-v61.dtsi
  create mode 100644 arch/arm/boot/dts/vf-mx4.dtsi
@@ -20,10 +20,10 @@ Subject: [PATCH] add-device-tree-for-c61-v61
 
 diff --git a/arch/arm/boot/dts/vf-mx4-c61.dtsi b/arch/arm/boot/dts/vf-mx4-c61.dtsi
 new file mode 100644
-index 000000000000..a927c4ca3fd9
+index 000000000000..f26fdcc358fb
 --- /dev/null
 +++ b/arch/arm/boot/dts/vf-mx4-c61.dtsi
-@@ -0,0 +1,201 @@
+@@ -0,0 +1,259 @@
 +/*
 + * Copyright 2016 Host Mobility AB
 + *
@@ -143,6 +143,64 @@ index 000000000000..a927c4ca3fd9
 +		interrupts = <20 IRQ_TYPE_EDGE_RISING>;
 +		gpios = <&gpio1 9 IRQ_TYPE_EDGE_RISING>;
 +		spi-cpha;
++		interrupt-controller;
++		gpio-controller;
++		gpio-line-names = 
++			"digital-out-1-source",
++			"digital-out-2-source",
++			"nc_1",
++			"nc_2",
++			"nc_3",
++			"nc_4",
++			"nc_5",
++			"digital-out-1-sink",
++			"digital-out-2-sink",
++			"nc_6",
++			"nc_7",
++			"nc_8",
++			"nc_9",
++			"nc_10",
++			"digital-out-en",
++			"digital-out-1",
++			"digital-out-2",
++			"nc_11",
++			"nc_12",
++			"nc_13",
++			"nc_14",
++			"vref",
++			"5V",
++			"3.3V",
++			"nc_15",
++			"nc_16",
++			"5V out",
++			"digital-in-1 / sc",
++			"digital-in-2 / sc",
++			"nc_17",
++			"nc_18",
++			"nc_19",
++			"nc_20",
++			"modem sync",
++			"modem ring",
++			"modem current ind",
++			"modem power ind",
++			"start switch",
++			"CAN-WAKEUP",
++			"MUX-IN-1",
++			"MUX-IN-2",
++			"CAN0-WAKEUP",
++			"CAN1-WAKEUP",
++			"CAN2-WAKEUP",
++			"CAN3-WAKEUP",
++			"CAN4-WAKEUP",
++			"CAN5-WAKEUP",
++			"MUX-OUT-1",
++			"MUX-OUT-2",
++			"nc_21",
++			"nc_22",
++			"nc_23",
++			"nc_24",
++			"nc_25",
++			"nc_26";
 +	};
 +
 +	mx4_pic: dspi@1 {
@@ -153,7 +211,7 @@ index 000000000000..a927c4ca3fd9
 +};
 +
 +&i2c2 {
-+	status = "disable";
++	status = "okay";
 +
 +	acc: mma8452q@1c {
 +		compatible = "fsl,mma8452";
@@ -227,10 +285,10 @@ index 000000000000..a927c4ca3fd9
 +};
 diff --git a/arch/arm/boot/dts/vf-mx4-v61.dtsi b/arch/arm/boot/dts/vf-mx4-v61.dtsi
 new file mode 100644
-index 000000000000..26e6ffdbf7bc
+index 000000000000..db67c78c9328
 --- /dev/null
 +++ b/arch/arm/boot/dts/vf-mx4-v61.dtsi
-@@ -0,0 +1,184 @@
+@@ -0,0 +1,242 @@
 +/*
 + * Copyright 2015 Host Mobility AB
 + *
@@ -333,10 +391,68 @@ index 000000000000..26e6ffdbf7bc
 +		interrupts = <20 IRQ_TYPE_EDGE_RISING>;
 +		gpios = <&gpio1 9 IRQ_TYPE_EDGE_RISING>;
 +		spi-cpha;
++		interrupt-controller;
++		gpio-controller;// old list for v61.
++		gpio-line-names = 
++			"digital-out-1-source",
++			"digital-out-2-source",
++			"digital-out-3-source",
++			"digital-out-4-source",
++			"digital-out-5-source",
++			"digital-out-6-sink",
++			"digital-out-7-sink",
++			"digital-out-1-sink",
++			"digital-out-2-sink",
++			"digital-out-3-sink",
++			"digital-out-4-sink",
++			"digital-out-5-sink",
++			"digital-out-6-source",
++			"digital-out-7-source",
++			"digital-out-en",
++			"digital-out-1",
++			"digital-out-2",
++			"digital-out-3",
++			"digital-out-4",
++			"digital-out-5 / 4-20mA",
++			"digital-out-6",
++			"vref",
++			"5V",
++			"3.3V",
++			"LIN sleep",
++			"LIN2 sleep",
++			"5V out",
++			"digital-in-1 / sc",
++			"digital-in-2 / sc",
++			"digital-in-3 / sc",
++			"digital-in-4 / sc",
++			"digital-in-5 / sc",
++			"digital-in-6",
++			"modem sync",
++			"modem ring",
++			"modem current ind",
++			"modem power ind",
++			"start switch",
++			"CAN-WAKEUP",
++			"MUX-IN-1",
++			"MUX-IN-2",
++			"CAN0-WAKEUP",
++			"CAN1-WAKEUP",
++			"CAN2-WAKEUP",
++			"CAN3-WAKEUP",
++			"CAN4-WAKEUP",
++			"CAN5-WAKEUP",
++			"MUX-OUT-1",
++			"MUX-OUT-2",
++			"LIN enabled",
++			"LIN2 enabled",
++			"digital-in-7",
++			"digital-in-8",
++			"digital-out-7",
++			"digital-out-8";
 +	};
 +
 +	mx4_pic: dspi@1 {
-+		compatible = "toradex,evalspi";
++		compatible = "hostmobility,mx4_pic";
 +		reg = <1>;
 +		spi-max-frequency = <50000000>;
 +	};
@@ -354,7 +470,7 @@ index 000000000000..26e6ffdbf7bc
 +		interrupts = <31 IRQ_TYPE_EDGE_FALLING>;
 +	};
 +
-+	rtc@51 {
++	rtc0: pcf85063@51 {
 +		compatible = "nxp,pcf85063";
 +		reg = <0x51>;
 +	};
@@ -417,7 +533,7 @@ index 000000000000..26e6ffdbf7bc
 +};
 diff --git a/arch/arm/boot/dts/vf-mx4.dtsi b/arch/arm/boot/dts/vf-mx4.dtsi
 new file mode 100644
-index 000000000000..8ba4c6131342
+index 000000000000..45f2fe863d04
 --- /dev/null
 +++ b/arch/arm/boot/dts/vf-mx4.dtsi
 @@ -0,0 +1,274 @@
@@ -748,10 +864,10 @@ index 000000000000..2bf5a2d5f6b0
 +};
 diff --git a/arch/arm/boot/dts/vf610-mx4.dtsi b/arch/arm/boot/dts/vf610-mx4.dtsi
 new file mode 100644
-index 000000000000..85ecfa8bd6ea
+index 000000000000..fd025fdc8202
 --- /dev/null
 +++ b/arch/arm/boot/dts/vf610-mx4.dtsi
-@@ -0,0 +1,104 @@
+@@ -0,0 +1,103 @@
 +/*
 + * Copyright 2015 Host Mobility AB
 + *
@@ -768,8 +884,7 @@ index 000000000000..85ecfa8bd6ea
 +	model = "Host Mobility AB MX-4 V61";
 +	compatible = "hostmobility,vf610-mx4_v61", "fsl,vf610";
 +
-+	memory@80000000 {
-+		device_type = "memory";
++	memory {
 +		reg = <0x80000000 0x10000000>;
 +	};
 +
@@ -857,5 +972,5 @@ index 000000000000..85ecfa8bd6ea
 +	};
 +};
 -- 
-2.17.1
+2.34.1
 


### PR DESCRIPTION
V61 keeps default names where c61 has some renamed to nc which is not connected.