### PR TITLE
HMX:Put back systemd-networkd

### DIFF
--- a/conf/machine/include/hmx-base.conf
+++ b/conf/machine/include/hmx-base.conf
@@ -9,6 +9,7 @@ IMAGE_INSTALL:remove = " \
 BBMASK += "\
 meta-hostmobility-bsp/recipes-bsp/libubootenv \
 meta-mobility-poky-distro/recipes-connectivity/networkmanager/networkmanager_%.bbappend \
+meta-variscite-bsp/recipes-core/systemd/systemd_%.bbappend \
 "
 
 PREFERRED_CONNECTIVITY_MANAGER_PACKAGES = ""

--- a/recipes-core/systemd/systemd/0001-units-add-dependencies-to-avoid-conflict-between-con.patch
+++ b/recipes-core/systemd/systemd/0001-units-add-dependencies-to-avoid-conflict-between-con.patch
@@ -1,0 +1,37 @@
+From b0daa2a427954d9c7b016c5651d56cd827e72678 Mon Sep 17 00:00:00 2001
+From: Marco Contenti <marco.contenti@variscite.com>
+Date: Sat, 3 Apr 2021 19:30:27 +0200
+Subject: [PATCH] units: add dependencies to avoid conflict between connman and
+ systemd-networkd
+
+---
+ units/systemd-networkd.service.in | 2 +-
+ units/systemd-networkd.socket     | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/units/systemd-networkd.service.in b/units/systemd-networkd.service.in
+index 01931665a4..11df55d8b8 100644
+--- a/units/systemd-networkd.service.in
++++ b/units/systemd-networkd.service.in
+@@ -13,7 +13,7 @@
+ ConditionCapability=CAP_NET_ADMIN
+ DefaultDependencies=no
+ # systemd-udevd.service can be dropped once tuntap is moved to netlink
+-After=systemd-networkd.socket systemd-udevd.service network-pre.target systemd-sysusers.service systemd-sysctl.service
++After=systemd-networkd.socket systemd-udevd.service network-pre.target systemd-sysusers.service systemd-sysctl.service connman.service
+ Before=network.target multi-user.target shutdown.target
+ Conflicts=shutdown.target
+ Wants=systemd-networkd.socket network.target
+diff --git a/units/systemd-networkd.socket b/units/systemd-networkd.socket
+index 113306607b..75459efbff 100644
+--- a/units/systemd-networkd.socket
++++ b/units/systemd-networkd.socket
+@@ -20,4 +20,4 @@
+ PassPacketInfo=yes
+ 
+ [Install]
+-WantedBy=sockets.target
++WantedBy=sockets.target systemd-networkd.service
+-- 
+2.31.1
+

--- a/recipes-core/systemd/systemd/0002-units-disable-systemd-networkd-wait-online-if-Networ.patch
+++ b/recipes-core/systemd/systemd/0002-units-disable-systemd-networkd-wait-online-if-Networ.patch
@@ -1,0 +1,32 @@
+From b57f7c88e9afd9021027332dd996aa4b0bec819a Mon Sep 17 00:00:00 2001
+From: Nate Drude <nate.d@variscite.com>
+Date: Tue, 17 Jan 2023 14:10:39 -0600
+Subject: [PATCH] units: disable systemd-networkd-wait-online if NetworkManager
+ is enabled
+
+Only one "wait" service should be enabled. Do not run this service
+if NetworkManager-wait-online is enabled.
+
+For more information, see https://www.freedesktop.org/wiki/Software/systemd/NetworkTarget/
+
+Signed-off-by: Nate Drude <nate.d@variscite.com>
+---
+ units/systemd-networkd-wait-online.service.in | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/units/systemd-networkd-wait-online.service.in b/units/systemd-networkd-wait-online.service.in
+index 10d8b08c8e..5d5c43e3f0 100644
+--- a/units/systemd-networkd-wait-online.service.in
++++ b/units/systemd-networkd-wait-online.service.in
+@@ -19,6 +19,8 @@ Before=network-online.target shutdown.target
+ [Service]
+ Type=oneshot
+ ExecStart={{ROOTLIBEXECDIR}}/systemd-networkd-wait-online
++ExecCondition=/bin/bash -c '! /bin/systemctl is-enabled NetworkManager-wait-online.service'
++ExecCondition=/bin/bash -c '! /bin/systemctl is-enabled connman-wait-online.service'
+ RemainAfterExit=yes
+ 
+ [Install]
+-- 
+2.39.0
+

--- a/recipes-core/systemd/systemd/imx.conf
+++ b/recipes-core/systemd/systemd/imx.conf
@@ -1,0 +1,3 @@
+[Login]
+# i.MX-specific
+HandlePowerKey=ignore

--- a/recipes-core/systemd/systemd_%.bbappend
+++ b/recipes-core/systemd/systemd_%.bbappend
@@ -1,0 +1,11 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/${BPN}:"
+
+SRC_URI:append:imx-generic-bsp = " file://imx.conf \
+            file://0001-units-add-dependencies-to-avoid-conflict-between-con.patch \
+            file://0002-units-disable-systemd-networkd-wait-online-if-Networ.patch \
+"
+
+do_install:append:imx-generic-bsp() {
+    install -Dm 0644 ${WORKDIR}/imx.conf ${D}${sysconfdir}/systemd/logind.conf.d/imx.conf
+}
+


### PR DESCRIPTION
Variscite wants to use NetworkManager, we want to use systemd-networkd. Since the meta-variscite-bsp/recipes-core/systemd/systemd_%.bbappend removes networkd, we cannot re-append it so we copy the bbappend recipe to our layer and BBMASK the variscite version.

(Tried forcevariable PACKAGECONFIG but that does not seem to work with kirstone, maybe another syntax?)