### PR TITLE
mx4-T30: fix kernel modules to image

### DIFF
--- a/conf/machine/include/mx4-tegra3-base.inc
+++ b/conf/machine/include/mx4-tegra3-base.inc
@@ -51,6 +51,7 @@ PREFERRED_PROVIDER_j1708-lib = "j1708-lib_1.0.6"
 PREFERRED_PROVIDER_j1708-test = "j1708-test_1.0.6"
 
 MACHINE_EXTRA_RDEPENDS += " \
+    kernel-modules \
     packagegroup-hostmobility-commercial \
     ${@bb.utils.contains('MACHINE_FEATURES', 'wifi', \
                           'linux-firmware-ath9k linux-firmware-wl18xx hostapd', '', d)} \


### PR DESCRIPTION
when we removed mx4-extra we forgot to add  kernel-modules to MACHINE_EXTRA_RDEPENDS. Tested and it works in kirkstone poky