### PR TITLE
T30(fr): Fix mx4_pic driver bad version magic

### DIFF
--- a/recipes-kernel/kernel-modules/kernel-module-pic_git.bb
+++ b/recipes-kernel/kernel-modules/kernel-module-pic_git.bb
@@ -17,5 +17,7 @@ SRC_URI[sha256sum] = "ece0c9ccbfb5d2771b115f750361184bb80b2ae5fe82d97d38be2bfee3
 
 S = "${WORKDIR}/git"
 
-KERNEL_MODULE_AUTOLOAD += "mx4_pic"
+DEPENDS += "virtual/kernel"
+KERNEL_SRC = "${STAGING_KERNEL_DIR}"
 
+KERNEL_MODULE_AUTOLOAD += "mx4_pic"

--- a/recipes-kernel/linux/linux-hostmobility_mainline-6.1.bb
+++ b/recipes-kernel/linux/linux-hostmobility_mainline-6.1.bb
@@ -12,8 +12,6 @@ COMPATIBLE_MACHINE = "(mx4-t30|vfcv61|mx4-hostcom)"
 
 LINUX_VERSION ?= "6.1.26"
 
-LOCALVERSION = "-${PR}"
-
 PV = "${LINUX_VERSION}"
 S = "${WORKDIR}/linux-${PV}"
 


### PR DESCRIPTION
mx4_pic: version magic
'6.1.26 SMP preempt mod_unload ARMv7 p2v8 '
should be
'6.1.26-r0 SMP preempt mod_unload ARMv7 p2v8 '

There is a -r0 in the expected vermagic.
It comes from the linux kernel local version
argument. Remove LOCALVERSION in kernel
mainline recipe.
Add depends on virtual/kernel in module recipe.