### PR TITLE
recipes-kernel: Adjust Linux license

### DIFF
--- a/recipes-kernel/linux/linux-hostmobility-vf_4.19.bb
+++ b/recipes-kernel/linux/linux-hostmobility-vf_4.19.bb
@@ -1,7 +1,7 @@
 
 SUMMARY = "Linux Kernel for Host Mobility products based on Toradex Tegra COMs"
 SECTION = "kernel"
-LICENSE = "GPLv2"
+LICENSE = "GPL-2.0-only"
 
 LIC_FILES_CHKSUM = "file://COPYING;md5=bbea815ee2795b2f4230826c0c6b8814"
 

--- a/recipes-kernel/linux/linux-hostmobility.inc
+++ b/recipes-kernel/linux/linux-hostmobility.inc
@@ -1,6 +1,6 @@
 SUMMARY = "Linux Kernel for Host Mobility products based on Toradex Tegra COMs"
 SECTION = "kernel"
-LICENSE = "GPLv2"
+LICENSE = "GPL-2.0-only"
 
 LIC_FILES_CHKSUM = "file://COPYING;md5=d7810fab7487fb0aad327b76f1be7cd7"
 

--- a/recipes-kernel/linux/linux-hostmobility_mainline-4.19.bb
+++ b/recipes-kernel/linux/linux-hostmobility_mainline-4.19.bb
@@ -1,6 +1,6 @@
 SUMMARY = "Linux Kernel for Host Mobility products based on Toradex Tegra COMs"
 SECTION = "kernel"
-LICENSE = "GPLv2"
+LICENSE = "GPL-2.0-only"
 
 LIC_FILES_CHKSUM = "file://COPYING;md5=bbea815ee2795b2f4230826c0c6b8814"
 

--- a/recipes-kernel/linux/linux-hostmobility_mainline-6.1.bb
+++ b/recipes-kernel/linux/linux-hostmobility_mainline-6.1.bb
@@ -1,6 +1,6 @@
 SUMMARY = "Linux Kernel for Host Mobility products based on Toradex Tegra COMs"
 SECTION = "kernel"
-LICENSE = "GPL-3.0-or-later"
+LICENSE = "GPL-2.0-only"
 
 LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
 FILESEXTRAPATHS:prepend := "${THISDIR}/linux-mobility-imx:"


### PR DESCRIPTION
- Change the license name from GPLv2 to GPL-2.0-only. It fixes the following build warning:
     "QA Issue: Recipe LICENSE includes obsolete licenses GPLv2 [obsolete-license]"

- Fix incorrect license for linux-hostmobility_mainline-6.1.b (Linux is not redistributable as GPL-3.0-or-later)