### PR TITLE
hmm: update gpio overlay driver

### DIFF
--- a/recipes-kernel/kernel-modules/gpio-overlay-hmm_1.0.bb
+++ b/recipes-kernel/kernel-modules/gpio-overlay-hmm_1.0.bb
@@ -2,13 +2,13 @@ SUMMARY = "gpio overlay"
 DESCRIPTION = "${SUMMARY} for Host Monitor Platforms"
 LICENSE = "GPL-2.0-or-later"
 LIC_FILES_CHKSUM = "file://COPYING;md5=65dd37ccb3e888dc57e47d925b80b38a"
-SRCREV = "e581bf893f46f2ae3a51a53d8adc564cb742385b"
+SRCREV = "030c709b5b221de5de9993393c5746460fbabb46"
 SRCBRANCH = "main"
 
 inherit module
 DEPENDS += "virtual/kernel"
 
-PR = "r1"
+PR = "r2"
 
 S = "${WORKDIR}/git/drivers/gpio/gpio_overlay_hmm"
 


### PR DESCRIPTION
add support for multiple enable analog in 20ma messurment pins. https://github.com/hostmobility/hm-commercial/commit/586c7beeced8701cb6c272a167459f830a1da7ed