### PR TITLE
hmm: change systemd-poweroff to reboot the system

### DIFF
--- a/recipes-core/systemd/systemd/verdin-am62-hmm/systemd-poweroff.service
+++ b/recipes-core/systemd/systemd/verdin-am62-hmm/systemd-poweroff.service
@@ -1,0 +1,20 @@
+#  SPDX-License-Identifier: LGPL-2.1-or-later
+#
+#  This file is part of systemd.
+#
+#  systemd is free software; you can redistribute it and/or modify it
+#  under the terms of the GNU Lesser General Public License as published by
+#  the Free Software Foundation; either version 2.1 of the License, or
+#  (at your option) any later version.
+
+[Unit]
+Description=System Power Off
+Documentation=man:systemd-poweroff.service(8)
+DefaultDependencies=no
+Requires=shutdown.target umount.target final.target
+After=shutdown.target umount.target final.target
+# Using `systemctl --force halt` instead of `shutdown-force` is to avoid PMIC power off on HMM. The watchdog driver will trigger shutdown from the M core instead.
+
+[Service]
+Type=oneshot
+ExecStart=systemctl --force halt

--- a/recipes-core/systemd/systemd_%.bbappend
+++ b/recipes-core/systemd/systemd_%.bbappend
@@ -5,7 +5,15 @@ SRC_URI:append:imx8mp-var-dart = " file://imx.conf \
             file://0002-units-disable-systemd-networkd-wait-online-if-Networ.patch \
             file://systemd-poweroff.service \
 "
+
+SRC_URI:append:verdin-am62-hmm = "
+            file://systemd-poweroff.service \
+"
 do_install:append:imx8mp-var-dart() {
     install -Dm 0644 ${WORKDIR}/imx.conf ${D}${sysconfdir}/systemd/logind.conf.d/imx.conf
+    install -Dm 0644 ${WORKDIR}/systemd-poweroff.service ${D}${systemd_system_unitdir}/systemd-poweroff.service
+}
+
+do_install:append:verdin-am62-hmm() {
     install -Dm 0644 ${WORKDIR}/systemd-poweroff.service ${D}${systemd_system_unitdir}/systemd-poweroff.service
 }


### PR DESCRIPTION
The base board does not have any way to restore itself when pmic is off. This is similar issue with the HMX but for the hmx it does have a way to shutdown (cut-off) with use of the m7(m4) co-cpu. This product variant right now does not have a start signal and therfore it can not enter shutdown.