### PR TITLE
hmm: hmm-base: add default path for deploy image and ipk

### DIFF
--- a/conf/machine/include/hmm-base.conf
+++ b/conf/machine/include/hmm-base.conf
@@ -36,5 +36,5 @@ KERNEL_DEVICETREE:remove = " \
 # Add wic.gz file type support to enable flashing using gzwrite in uboot
 IMAGE_FSTYPES:append = " wic.gz"
 
-#Fixup default deploy dir(images) to make it same as our other machines.
+# Use the same deploy directory for images as for the other machines.
 TI_COMMON_DEPLOY = "${DEPLOY_DIR}"

--- a/conf/machine/include/hmm-base.conf
+++ b/conf/machine/include/hmm-base.conf
@@ -35,3 +35,6 @@ KERNEL_DEVICETREE:remove = " \
 
 # Add wic.gz file type support to enable flashing using gzwrite in uboot
 IMAGE_FSTYPES:append = " wic.gz"
+
+#Fixup default deploy dir(images) to make it same as our other machines.
+TI_COMMON_DEPLOY = "${DEPLOY_DIR}"


### PR DESCRIPTION
since we use the default on the rest of the machine this would be eiser for us to deploy under same deploy directory.
the new path for hmm will be build-hmm/tmp-glibc/deploy/images/verdin-am62-hmm instead of build-hmm/deploy-ti/images/verdin-am62-hmm