### PR TITLE
network.target fix

### DIFF
--- a/recipes-core/systemd/systemd/verdin-am62-hmm/wait-for-network.service
+++ b/recipes-core/systemd/systemd/verdin-am62-hmm/wait-for-network.service
@@ -1,0 +1,12 @@
+#  SPDX-License-Identifier: LGPL-2.1-or-later
+
+[Unit]
+Description=Wait for network
+Before=network.target
+
+[Service]
+Type=oneshot
+ExecStart=/bin/sleep 6
+
+[Install]
+WantedBy=network.target

--- a/recipes-core/systemd/systemd_%.bbappend
+++ b/recipes-core/systemd/systemd_%.bbappend
@@ -6,7 +6,10 @@ SRC_URI:append:imx8mp-var-dart = " file://imx.conf \
             file://systemd-poweroff.service \
 "
 
-SRC_URI:append:verdin-am62-hmm = " file://systemd-poweroff.service"
+SRC_URI:append:verdin-am62-hmm = "  \
+            file://systemd-poweroff.service \
+            file://wait-for-network.service \
+"
 
 do_install:append:imx8mp-var-dart() {
     install -Dm 0644 ${WORKDIR}/imx.conf ${D}${sysconfdir}/systemd/logind.conf.d/imx.conf
@@ -15,4 +18,5 @@ do_install:append:imx8mp-var-dart() {
 
 do_install:append:verdin-am62-hmm() {
     install -Dm 0644 ${WORKDIR}/systemd-poweroff.service ${D}${systemd_system_unitdir}/systemd-poweroff.service
+    install -Dm 0644 ${WORKDIR}/wait-for-network.service ${D}${systemd_system_unitdir}/wait-for-network.service
 }


### PR DESCRIPTION
Add delay to postpone network.target since the hmm have an observed behviour of making the flag appear to early in the systemd boot process, this can cause the system to reboot itself if the system is loaded with heavy computional services during startup since the watchdog timer will run out. 