### PR TITLE
hmm-base: add recipes to BBMASK

### DIFF
--- a/conf/machine/include/hmm-base.conf
+++ b/conf/machine/include/hmm-base.conf
@@ -1,7 +1,10 @@
 BBMASK += "\
     meta-hostmobility-bsp/recipes-bsp/libubootenv \
     meta-hostmobility-bsp/recipes-bsp/u-boot \
+    meta-hostmobility-bsp/recipes-bsp/udev \
+    meta-hostmobility-bsp/recipes-bsp/firmware-imx \
     meta-hostmobility-bsp/recipes-kernel/linux \
+    meta-mobility-c2-distro/recipes-kernel/linux \
 "
 
 PREFERRED_CONNECTIVITY_MANAGER_PACKAGES = ""


### PR DESCRIPTION
Mask HMX-specific recipes (udev, firmware-imx) from meta-hostmobility-bsp and deprecated C61 kernel recipe from meta-mobility-c2-distro.

Fixes bitbake parse warnings for HMM builds.