### PR TITLE
autostart service: Start from systemd timer after boot

### DIFF
--- a/recipes-bsp/hm-autostart/hm-autostart.bb
+++ b/recipes-bsp/hm-autostart/hm-autostart.bb
@@ -1,35 +1,46 @@
+DESCRIPTION = "Installs HM autostart script and a machine-dependent systemd timer to run it after boot"
+
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
 
-SRC_URI += "\
+FILESEXTRAPATHS:prepend := "${THISDIR}/${MACHINE}:${THISDIR}/${BPN}:"
+
+SRC_URI = " \
     file://autostart.service \
     file://autostart.sh \
+    file://autostart.timer \
 "
+
 inherit systemd
 
 DEPENDS = "virtual/kernel"
-
-SYSTEMD_PACKAGES = "${PN}"
-
-SYSTEMD_SERVICE:${PN} = "autostart.service"
 RDEPENDS:${PN} = "bash"
 
+SYSTEMD_PACKAGES = "${PN}"
+SYSTEMD_SERVICE:${PN} = "autostart.timer"
+
 do_install() {
-    install -d ${D}/${sysconfdir}
-    install -d ${D}${systemd_unitdir}/system/
-    install -d ${D}/opt/hm/
+    install -d ${D}${sysconfdir}
+    install -d ${D}${systemd_unitdir}/system
+    install -d ${D}/opt/hm
 
     # Legacy file and method to indicate that it is first-time boot
-    touch ${D}/${sysconfdir}/first_boot_after_update.txt
+    touch ${D}${sysconfdir}/first_boot_after_update.txt
     # Indicate that the hostname file is not yet fully written
-    touch ${D}/${sysconfdir}/hostname_from_eeprom_pending.txt
+    touch ${D}${sysconfdir}/hostname_from_eeprom_pending.txt
 
-    install -m 0644 ${WORKDIR}/autostart.service ${D}${systemd_unitdir}/system/autostart.service
-    install -m 0755 ${WORKDIR}/autostart.sh ${D}/opt/hm/autostart.sh
+    install -m 0644 ${WORKDIR}/autostart.service \
+        ${D}${systemd_unitdir}/system/autostart.service
+    install -m 0644 ${WORKDIR}/autostart.timer \
+        ${D}${systemd_unitdir}/system/autostart.timer
+    install -m 0755 ${WORKDIR}/autostart.sh \
+        ${D}/opt/hm/autostart.sh
 }
-FILES:${PN} = "\
+
+FILES:${PN} = " \
     /opt/hm/autostart.sh \
     ${systemd_unitdir}/system/autostart.service \
+    ${systemd_unitdir}/system/autostart.timer \
     ${sysconfdir}/first_boot_after_update.txt \
     ${sysconfdir}/hostname_from_eeprom_pending.txt \
 "

--- a/recipes-bsp/hm-autostart/hm-autostart/autostart.service
+++ b/recipes-bsp/hm-autostart/hm-autostart/autostart.service
@@ -1,11 +1,7 @@
 [Unit]
-Description=Run autostart scripts
-After=network-pre.target
+Description=Run autostart script
 
 [Service]
 Type=oneshot
 RemainAfterExit=yes
-ExecStart = /opt/hm/autostart.sh
-
-[Install]
-WantedBy=multi-user.target
+ExecStart=/opt/hm/autostart.sh

--- a/recipes-bsp/hm-autostart/hm-autostart/autostart.timer
+++ b/recipes-bsp/hm-autostart/hm-autostart/autostart.timer
@@ -1,0 +1,9 @@
+[Unit]
+Description=Run autostart 15 seconds after boot
+
+[Timer]
+OnBootSec=15s
+Unit=autostart.service
+
+[Install]
+WantedBy=timers.target

--- a/recipes-bsp/hm-autostart/imx8mp-var-dart/autostart.timer
+++ b/recipes-bsp/hm-autostart/imx8mp-var-dart/autostart.timer
@@ -1,0 +1,9 @@
+[Unit]
+Description=Run autostart 15 seconds after boot
+
+[Timer]
+OnBootSec=15s
+Unit=autostart.service
+
+[Install]
+WantedBy=timers.target

--- a/recipes-bsp/hm-autostart/verdin-am62-hmm/autostart.timer
+++ b/recipes-bsp/hm-autostart/verdin-am62-hmm/autostart.timer
@@ -1,0 +1,9 @@
+[Unit]
+Description=Run autostart 30 seconds after boot
+
+[Timer]
+OnBootSec=30s
+Unit=autostart.service
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
This changes autostart from starting after a specific systemd target to starting from a machine-dependent systemd timer, with a 15s fallback for other machines. This gives more control over when it runs, independent of systemd service ordering.