### PR TITLE
HMX: change linux kernel to 6.6.119

### DIFF
--- a/dynamic-layers/variscite-nxp-layer/recipes-kernel/linux/linux-variscite/0001-Add-Kinetic-KTD2026-2027-LED-driver.patch
+++ b/dynamic-layers/variscite-nxp-layer/recipes-kernel/linux/linux-variscite/0001-Add-Kinetic-KTD2026-2027-LED-driver.patch
@@ -1,6 +1,6 @@
-From c09bdfb628392d915e3b2bf5aa4c37cd7128f3a7 Mon Sep 17 00:00:00 2001
+From 140a81a7ce72f426a316171775207536030c6be6 Mon Sep 17 00:00:00 2001
 From: rikardo <rikard.olander@hostmobility.com>
-Date: Tue, 3 Oct 2023 14:51:19 +0000
+Date: Tue, 21 Apr 2026 12:01:29 +0200
 Subject: [PATCH 1/1] Add Kinetic KTD2026/2027 LED driver
  Changes in v3:
     - Add max-brightness from device tree
@@ -261,7 +261,7 @@ index c11cc56384e7..819ca84220da 100644
 +obj-$(CONFIG_LEDS_KTD202X)		+= leds-ktd202x.o
 diff --git a/drivers/leds/rgb/leds-ktd202x.c b/drivers/leds/rgb/leds-ktd202x.c
 new file mode 100644
-index 000000000000..c34a0239f6fa
+index 000000000000..8e2067339efe
 --- /dev/null
 +++ b/drivers/leds/rgb/leds-ktd202x.c
 @@ -0,0 +1,703 @@
@@ -969,5 +969,5 @@ index 000000000000..c34a0239f6fa
 +MODULE_DESCRIPTION("Kinetic KTD2026/7 LED driver");
 +MODULE_LICENSE("GPL");
 -- 
-2.34.1
+2.47.3
 

--- a/dynamic-layers/variscite-nxp-layer/recipes-kernel/linux/linux-variscite/0001-add-hmx-device-tree.patch
+++ b/dynamic-layers/variscite-nxp-layer/recipes-kernel/linux/linux-variscite/0001-add-hmx-device-tree.patch
@@ -1,6 +1,6 @@
-From f79b63f046b1a8b9971849eedfda275d1907ea48 Mon Sep 17 00:00:00 2001
-From: Andreas Ternstedt <a.ternstedt@setek.se>
-Date: Tue, 26 Aug 2025 14:09:04 +0200
+From d69f9c4a1882f560bcc4b03d18bc8d47025a8f47 Mon Sep 17 00:00:00 2001
+From: rikardo <rikard.olander@hostmobility.com>
+Date: Tue, 21 Apr 2026 12:00:04 +0200
 Subject: [PATCH 1/1] arm64: dts: freescale: Add HMX device tree for kernel 6.6
 
 Add complete device tree for HMX board based on Variscite
@@ -31,7 +31,7 @@ Notable configurations:
 This device tree consolidates previously separate patches for
 maintainability and provides complete HMX board support.
 
-Based on Variscite Linux kernel version: lf-6.6.y_6.6.52-2.2.0_var01
+Based on Variscite Linux kernel version: 6.6-2.2.x-imx_var01 (a242d114c51c61a84b84ce03cb00dd6573c879b4)
 
 Signed-off-by: rikardo <rikard.olander@hostmobility.com>
 Signed-off-by: Andreas Ternstedt <a.ternstedt@setek.se>
@@ -76,10 +76,10 @@ Notes:
  create mode 100644 arch/arm64/boot/dts/freescale/imx8mp-var-dart-hmx1.dts
 
 diff --git a/arch/arm64/boot/dts/freescale/Makefile b/arch/arm64/boot/dts/freescale/Makefile
-index ae88ecfee4c3..edf0ad985149 100644
+index a7cc21925676..3bb1bc95e93a 100644
 --- a/arch/arm64/boot/dts/freescale/Makefile
 +++ b/arch/arm64/boot/dts/freescale/Makefile
-@@ -164,6 +164,7 @@ dtb-$(CONFIG_ARCH_MXC) += imx8mp-evk.dtb imx8mp-evk-rm67191.dtb imx8mp-evk-it626
+@@ -230,6 +230,7 @@ dtb-$(CONFIG_ARCH_MXC) += imx8mp-evk.dtb imx8mp-evk-rm67191.dtb imx8mp-evk-it626
  			  imx8mp-evk-usdhc1-m2.dtb imx8mp-evk-rm67199.dtb \
  			  imx8mp-evk-dpdk.dtb imx8mp-evk-8mic-swpdm.dtb imx8mp-evk-rpmsg-lpv.dtb imx8mp-evk-revA3-8mic-revE.dtb
  
@@ -87,7 +87,7 @@ index ae88ecfee4c3..edf0ad985149 100644
  dtb-$(CONFIG_ARCH_MXC) += imx8mp-var-dart-dt8mcustomboard.dtb
  dtb-$(CONFIG_ARCH_MXC) += imx8mp-var-dart-dt8mcustomboard-basler-isi0-m7.dtb
  dtb-$(CONFIG_ARCH_MXC) += imx8mp-var-dart-dt8mcustomboard-basler-isi0.dtb
-@@ -171,6 +172,7 @@ dtb-$(CONFIG_ARCH_MXC) += imx8mp-var-dart-dt8mcustomboard-basler-isp0-m7.dtb
+@@ -237,6 +238,7 @@ dtb-$(CONFIG_ARCH_MXC) += imx8mp-var-dart-dt8mcustomboard-basler-isp0-m7.dtb
  dtb-$(CONFIG_ARCH_MXC) += imx8mp-var-dart-dt8mcustomboard-basler-isp0.dtb
  dtb-$(CONFIG_ARCH_MXC) += imx8mp-var-dart-dt8mcustomboard-m7.dtb
  
@@ -95,7 +95,7 @@ index ae88ecfee4c3..edf0ad985149 100644
  imx8mp-var-dart-1.x-dt8mcustomboard-dtbs := imx8mp-var-dart-dt8mcustomboard.dtb imx8mp-var-dart-1.x.dtbo
  imx8mp-var-dart-1.x-dt8mcustomboard-basler-isi0-m7-dtbs := imx8mp-var-dart-dt8mcustomboard-basler-isi0-m7.dtb imx8mp-var-dart-1.x.dtbo
  imx8mp-var-dart-1.x-dt8mcustomboard-basler-isi0-dtbs := imx8mp-var-dart-dt8mcustomboard-basler-isi0.dtb imx8mp-var-dart-1.x.dtbo
-@@ -185,6 +187,7 @@ imx8mp-var-dart-wbe-dt8mcustomboard-basler-isp0-m7-dtbs := imx8mp-var-dart-dt8mc
+@@ -251,6 +253,7 @@ imx8mp-var-dart-wbe-dt8mcustomboard-basler-isp0-m7-dtbs := imx8mp-var-dart-dt8mc
  imx8mp-var-dart-wbe-dt8mcustomboard-basler-isp0-dtbs := imx8mp-var-dart-dt8mcustomboard-basler-isp0.dtb imx8mp-var-dart-wbe.dtbo
  imx8mp-var-dart-wbe-dt8mcustomboard-m7-dtbs := imx8mp-var-dart-dt8mcustomboard-m7.dtb imx8mp-var-dart-wbe.dtbo
  
@@ -105,7 +105,7 @@ index ae88ecfee4c3..edf0ad985149 100644
  dtb-$(CONFIG_ARCH_MXC) += imx8mp-var-dart-1.x-dt8mcustomboard-basler-isi0.dtb
 diff --git a/arch/arm64/boot/dts/freescale/imx8mp-var-dart-hmx1.dts b/arch/arm64/boot/dts/freescale/imx8mp-var-dart-hmx1.dts
 new file mode 100644
-index 000000000000..74b820aa8149
+index 000000000000..7dfa45928998
 --- /dev/null
 +++ b/arch/arm64/boot/dts/freescale/imx8mp-var-dart-hmx1.dts
 @@ -0,0 +1,1328 @@
@@ -1438,5 +1438,5 @@ index 000000000000..74b820aa8149
 +	};
 +};
 -- 
-2.34.1
+2.47.3
 

--- a/dynamic-layers/variscite-nxp-layer/recipes-kernel/linux/linux-variscite/0002-Set-I2C1-for-imx8mp-var-dart.dtsi-to-lower-clock-fre.patch
+++ b/dynamic-layers/variscite-nxp-layer/recipes-kernel/linux/linux-variscite/0002-Set-I2C1-for-imx8mp-var-dart.dtsi-to-lower-clock-fre.patch
@@ -1,6 +1,6 @@
-From 04d5964bb4caef4a9d131828ebaf6967e1e29b73 Mon Sep 17 00:00:00 2001
+From f4b284b2b655c3df2bed377055f89f34e2073600 Mon Sep 17 00:00:00 2001
 From: rikardo <rikard.olander@hostmobility.com>
-Date: Thu, 2 Mar 2023 16:14:20 +0000
+Date: Tue, 21 Apr 2026 12:02:06 +0200
 Subject: [PATCH 1/1] imx8mp-var-dart: reduce I2C1 clock frequency per errata
 
 Lower I2C1 clock-frequency from 400 kHz to 384 kHz to comply with
@@ -18,7 +18,7 @@ Signed-off-by: Andreas Ternstedt <a.ternstedt@setek.com>
  1 file changed, 2 insertions(+), 5 deletions(-)
 
 diff --git a/arch/arm64/boot/dts/freescale/imx8mp-var-dart.dtsi b/arch/arm64/boot/dts/freescale/imx8mp-var-dart.dtsi
-index c64cbe80e620..31ecea223945 100644
+index 5631265d1ec9..058cd563bdea 100644
 --- a/arch/arm64/boot/dts/freescale/imx8mp-var-dart.dtsi
 +++ b/arch/arm64/boot/dts/freescale/imx8mp-var-dart.dtsi
 @@ -147,12 +147,9 @@ &gpu_reserved {
@@ -37,5 +37,5 @@ index c64cbe80e620..31ecea223945 100644
  
  	pca9450@25 {
 -- 
-2.34.1
+2.47.3
 

--- a/dynamic-layers/variscite-nxp-layer/recipes-kernel/linux/linux-variscite/0003-tcan4x5x-backport-m_can-driver-from-kernel-6.12.20.patch
+++ b/dynamic-layers/variscite-nxp-layer/recipes-kernel/linux/linux-variscite/0003-tcan4x5x-backport-m_can-driver-from-kernel-6.12.20.patch
@@ -1,7 +1,7 @@
-From 99a3afdef66c02273278fd48ef995e5526adf440 Mon Sep 17 00:00:00 2001
+From d6629b305bdd9c6a1dc1fb10273db4827a817c3d Mon Sep 17 00:00:00 2001
 From: Andreas Ternstedt <andreas.ternstedt@gmail.com>
-Date: Thu, 13 Nov 2025 10:50:40 +0100
-Subject: [PATCH] TCAN4x5x: backport m_can driver from kernel 6.12.20
+Date: Tue, 21 Apr 2026 12:03:46 +0200
+Subject: [PATCH 1/1] TCAN4x5x: backport m_can driver from kernel 6.12.20
 
 Backport complete m_can driver subsystem from Variscite's lf-6.12.y
 kernel (lf-6.12.20-2.0.0_var01) to replace previous patch series.
@@ -23,16 +23,16 @@ Signed-off-by: Andreas Ternstedt <andreas.ternstedt@gmail.com>
 Signed-off-by: Rikard Olander <rikard.olander@hostmobility.com>
 
 ---
- drivers/net/can/m_can/m_can.c          | 863 ++++++++++++++++++-------
+ drivers/net/can/m_can/m_can.c          | 813 ++++++++++++++++++-------
  drivers/net/can/m_can/m_can.h          |  38 +-
  drivers/net/can/m_can/m_can_pci.c      |   4 +-
  drivers/net/can/m_can/m_can_platform.c |   9 +-
  drivers/net/can/m_can/tcan4x5x-core.c  |  48 +-
- include/linux/netdevice.h              | 24 ++++++++++++++++++++++++
- 6 files changed, 723 insertions(+), 263 deletions(-)
+ include/linux/netdevice.h              |  24 +
+ 6 files changed, 691 insertions(+), 245 deletions(-)
 
 diff --git a/drivers/net/can/m_can/m_can.c b/drivers/net/can/m_can/m_can.c
-index fb77fd74de27..97cd8bbf2e32 100644
+index e6a74d66f0d8..71c2700f34b3 100644
 --- a/drivers/net/can/m_can/m_can.c
 +++ b/drivers/net/can/m_can/m_can.c
 @@ -255,6 +255,7 @@ enum m_can_reg {
@@ -201,16 +201,16 @@ index fb77fd74de27..97cd8bbf2e32 100644
  
 -	if (cdev->tx_skb) {
 -		int putidx = 0;
--
--		net->stats.tx_errors++;
--		if (cdev->version > 30)
--			putidx = FIELD_GET(TXFQS_TFQPI_MASK,
--					   m_can_read(cdev, M_CAN_TXFQS));
 +	if (cdev->tx_ops) {
 +		for (int i = 0; i != cdev->tx_fifo_size; ++i) {
 +			if (!cdev->tx_ops[i].skb)
 +				continue;
  
+-		net->stats.tx_errors++;
+-		if (cdev->version > 30)
+-			putidx = FIELD_GET(TXFQS_TFQPI_MASK,
+-					   m_can_read(cdev, M_CAN_TXFQS));
+-
 -		can_free_echo_skb(cdev->net, putidx, NULL);
 -		cdev->tx_skb = NULL;
 +			net->stats.tx_errors++;
@@ -229,78 +229,7 @@ index fb77fd74de27..97cd8bbf2e32 100644
  }
  
  /* For peripherals, pass skb to rx-offload, which will push skb from
-@@ -636,47 +695,60 @@ static int m_can_handle_lec_err(struct net_device *dev,
- 	u32 timestamp = 0;
- 
- 	cdev->can.can_stats.bus_error++;
--	stats->rx_errors++;
- 
- 	/* propagate the error condition to the CAN stack */
- 	skb = alloc_can_err_skb(dev, &cf);
--	if (unlikely(!skb))
--		return 0;
- 
- 	/* check for 'last error code' which tells us the
- 	 * type of the last error to occur on the CAN bus
- 	 */
--	cf->can_id |= CAN_ERR_PROT | CAN_ERR_BUSERROR;
-+	if (likely(skb))
-+		cf->can_id |= CAN_ERR_PROT | CAN_ERR_BUSERROR;
- 
- 	switch (lec_type) {
- 	case LEC_STUFF_ERROR:
- 		netdev_dbg(dev, "stuff error\n");
--		cf->data[2] |= CAN_ERR_PROT_STUFF;
-+		stats->rx_errors++;
-+		if (likely(skb))
-+			cf->data[2] |= CAN_ERR_PROT_STUFF;
- 		break;
- 	case LEC_FORM_ERROR:
- 		netdev_dbg(dev, "form error\n");
--		cf->data[2] |= CAN_ERR_PROT_FORM;
-+		stats->rx_errors++;
-+		if (likely(skb))
-+			cf->data[2] |= CAN_ERR_PROT_FORM;
- 		break;
- 	case LEC_ACK_ERROR:
- 		netdev_dbg(dev, "ack error\n");
--		cf->data[3] = CAN_ERR_PROT_LOC_ACK;
-+		stats->tx_errors++;
-+		if (likely(skb))
-+			cf->data[3] = CAN_ERR_PROT_LOC_ACK;
- 		break;
- 	case LEC_BIT1_ERROR:
- 		netdev_dbg(dev, "bit1 error\n");
--		cf->data[2] |= CAN_ERR_PROT_BIT1;
-+		stats->tx_errors++;
-+		if (likely(skb))
-+			cf->data[2] |= CAN_ERR_PROT_BIT1;
- 		break;
- 	case LEC_BIT0_ERROR:
- 		netdev_dbg(dev, "bit0 error\n");
--		cf->data[2] |= CAN_ERR_PROT_BIT0;
-+		stats->tx_errors++;
-+		if (likely(skb))
-+			cf->data[2] |= CAN_ERR_PROT_BIT0;
- 		break;
- 	case LEC_CRC_ERROR:
- 		netdev_dbg(dev, "CRC error\n");
--		cf->data[3] = CAN_ERR_PROT_LOC_CRC_SEQ;
-+		stats->rx_errors++;
-+		if (likely(skb))
-+			cf->data[3] = CAN_ERR_PROT_LOC_CRC_SEQ;
- 		break;
- 	default:
- 		break;
- 	}
- 
-+	if (unlikely(!skb))
-+		return 0;
-+
- 	if (cdev->is_peripheral)
- 		timestamp = m_can_get_timestamp(cdev);
- 
-@@ -977,22 +1049,6 @@ static int m_can_rx_handler(struct net_device *dev, int quota, u32 irqstatus)
+@@ -990,22 +1049,6 @@ static int m_can_rx_handler(struct net_device *dev, int quota, u32 irqstatus)
  	return work_done;
  }
  
@@ -323,7 +252,7 @@ index fb77fd74de27..97cd8bbf2e32 100644
  static int m_can_poll(struct napi_struct *napi, int quota)
  {
  	struct net_device *dev = napi->dev;
-@@ -1019,23 +1075,60 @@ static int m_can_poll(struct napi_struct *napi, int quota)
+@@ -1032,23 +1075,60 @@ static int m_can_poll(struct napi_struct *napi, int quota)
   * echo. timestamp is used for peripherals to ensure correct ordering
   * by rx-offload, and is ignored for non-peripherals.
   */
@@ -389,7 +318,7 @@ index fb77fd74de27..97cd8bbf2e32 100644
  }
  
  static int m_can_echo_tx_event(struct net_device *dev)
-@@ -1047,6 +1140,8 @@ static int m_can_echo_tx_event(struct net_device *dev)
+@@ -1060,6 +1140,8 @@ static int m_can_echo_tx_event(struct net_device *dev)
  	int i = 0;
  	int err = 0;
  	unsigned int msg_mark;
@@ -398,7 +327,7 @@ index fb77fd74de27..97cd8bbf2e32 100644
  
  	struct m_can_classdev *cdev = netdev_priv(dev);
  
-@@ -1075,31 +1170,82 @@ static int m_can_echo_tx_event(struct net_device *dev)
+@@ -1088,31 +1170,82 @@ static int m_can_echo_tx_event(struct net_device *dev)
  		fgi = (++fgi >= cdev->mcfg[MRAM_TXE].num ? 0 : fgi);
  
  		/* update stats */
@@ -490,7 +419,7 @@ index fb77fd74de27..97cd8bbf2e32 100644
  	if (cdev->ops->clear_interrupts)
  		cdev->ops->clear_interrupts(cdev);
  
-@@ -1108,13 +1254,15 @@ static irqreturn_t m_can_isr(int irq, void *dev_id)
+@@ -1121,13 +1254,15 @@ static irqreturn_t m_can_isr(int irq, void *dev_id)
  	 * - state change IRQ
  	 * - bus error IRQ and bus error reporting
  	 */
@@ -509,7 +438,7 @@ index fb77fd74de27..97cd8bbf2e32 100644
  		}
  	}
  
-@@ -1122,21 +1270,19 @@ static irqreturn_t m_can_isr(int irq, void *dev_id)
+@@ -1135,21 +1270,19 @@ static irqreturn_t m_can_isr(int irq, void *dev_id)
  		if (ir & IR_TC) {
  			/* Transmission Complete Interrupt*/
  			u32 timestamp = 0;
@@ -538,7 +467,7 @@ index fb77fd74de27..97cd8bbf2e32 100644
  		}
  	}
  
-@@ -1144,10 +1290,34 @@ static irqreturn_t m_can_isr(int irq, void *dev_id)
+@@ -1157,10 +1290,34 @@ static irqreturn_t m_can_isr(int irq, void *dev_id)
  		can_rx_offload_threaded_irq_finish(&cdev->offload);
  
  	return IRQ_HANDLED;
@@ -576,7 +505,7 @@ index fb77fd74de27..97cd8bbf2e32 100644
  }
  
  static const struct can_bittiming_const m_can_bittiming_const_30X = {
-@@ -1288,11 +1458,13 @@ static int m_can_chip_config(struct net_device *dev)
+@@ -1301,11 +1458,13 @@ static int m_can_chip_config(struct net_device *dev)
  	}
  
  	/* Disable unused interrupts */
@@ -594,7 +523,7 @@ index fb77fd74de27..97cd8bbf2e32 100644
  
  	/* RX Buffer/FIFO Element Size 64 bytes data field */
  	m_can_write(cdev, M_CAN_RXESC,
-@@ -1327,6 +1499,8 @@ static int m_can_chip_config(struct net_device *dev)
+@@ -1340,6 +1499,8 @@ static int m_can_chip_config(struct net_device *dev)
  	} else {
  		/* Full TX Event FIFO is used */
  		m_can_write(cdev, M_CAN_TXEFC,
@@ -603,7 +532,7 @@ index fb77fd74de27..97cd8bbf2e32 100644
  			    FIELD_PREP(TXEFC_EFS_MASK,
  				       cdev->mcfg[MRAM_TXE].num) |
  			    cdev->mcfg[MRAM_TXE].off);
-@@ -1334,6 +1508,7 @@ static int m_can_chip_config(struct net_device *dev)
+@@ -1347,6 +1508,7 @@ static int m_can_chip_config(struct net_device *dev)
  
  	/* rx fifo configuration, blocking mode, fifo size 1 */
  	m_can_write(cdev, M_CAN_RXF0C,
@@ -611,7 +540,7 @@ index fb77fd74de27..97cd8bbf2e32 100644
  		    FIELD_PREP(RXFC_FS_MASK, cdev->mcfg[MRAM_RXF0].num) |
  		    cdev->mcfg[MRAM_RXF0].off);
  
-@@ -1392,7 +1567,8 @@ static int m_can_chip_config(struct net_device *dev)
+@@ -1405,7 +1567,8 @@ static int m_can_chip_config(struct net_device *dev)
  		else
  			interrupts &= ~(IR_ERR_LEC_31X);
  	}
@@ -621,7 +550,7 @@ index fb77fd74de27..97cd8bbf2e32 100644
  
  	/* route all interrupts to INT0 */
  	m_can_write(cdev, M_CAN_ILS, ILS_ALL_INT0);
-@@ -1407,7 +1583,9 @@ static int m_can_chip_config(struct net_device *dev)
+@@ -1420,7 +1583,9 @@ static int m_can_chip_config(struct net_device *dev)
  		    FIELD_PREP(TSCC_TCP_MASK, 0xf) |
  		    FIELD_PREP(TSCC_TSS_MASK, TSCC_TSS_INTERNAL));
  
@@ -632,7 +561,7 @@ index fb77fd74de27..97cd8bbf2e32 100644
  
  	if (cdev->ops->init)
  		cdev->ops->init(cdev);
-@@ -1425,11 +1603,22 @@ static int m_can_start(struct net_device *dev)
+@@ -1438,11 +1603,22 @@ static int m_can_start(struct net_device *dev)
  	if (ret)
  		return ret;
  
@@ -656,7 +585,7 @@ index fb77fd74de27..97cd8bbf2e32 100644
  }
  
  static int m_can_set_mode(struct net_device *dev, enum can_mode mode)
-@@ -1478,43 +1667,37 @@ static int m_can_check_core_release(struct m_can_classdev *cdev)
+@@ -1491,43 +1667,37 @@ static int m_can_check_core_release(struct m_can_classdev *cdev)
  }
  
  /* Selectable Non ISO support only in version 3.2.x
@@ -718,7 +647,7 @@ index fb77fd74de27..97cd8bbf2e32 100644
  
  	m_can_version = m_can_check_core_release(cdev);
  	/* return if unsupported version */
-@@ -1524,6 +1707,14 @@ static int m_can_dev_setup(struct m_can_classdev *cdev)
+@@ -1537,6 +1707,14 @@ static int m_can_dev_setup(struct m_can_classdev *cdev)
  		return -EINVAL;
  	}
  
@@ -733,7 +662,7 @@ index fb77fd74de27..97cd8bbf2e32 100644
  	if (!cdev->is_peripheral)
  		netif_napi_add(dev, &cdev->napi, m_can_poll);
  
-@@ -1563,9 +1754,11 @@ static int m_can_dev_setup(struct m_can_classdev *cdev)
+@@ -1576,9 +1754,11 @@ static int m_can_dev_setup(struct m_can_classdev *cdev)
  		cdev->can.bittiming_const = &m_can_bittiming_const_31X;
  		cdev->can.data_bittiming_const = &m_can_data_bittiming_const_31X;
  
@@ -748,7 +677,7 @@ index fb77fd74de27..97cd8bbf2e32 100644
  		break;
  	default:
  		dev_err(cdev->dev, "Unsupported version number: %2d",
-@@ -1573,21 +1766,22 @@ static int m_can_dev_setup(struct m_can_classdev *cdev)
+@@ -1586,21 +1766,22 @@ static int m_can_dev_setup(struct m_can_classdev *cdev)
  		return -EINVAL;
  	}
  
@@ -775,35 +704,18 @@ index fb77fd74de27..97cd8bbf2e32 100644
  
  	/* set the state as STOPPED */
  	cdev->can.state = CAN_STATE_STOPPED;
-@@ -1599,78 +1793,64 @@ static int m_can_close(struct net_device *dev)
+@@ -1616,8 +1797,9 @@ static int m_can_close(struct net_device *dev)
+ 	if (dev->irq)
+ 		free_irq(dev->irq, dev);
  
- 	netif_stop_queue(dev);
- 
--	if (!cdev->is_peripheral)
--		napi_disable(&cdev->napi);
--
- 	m_can_stop(dev);
--	m_can_clk_stop(cdev);
--	free_irq(dev->irq, dev);
-+	if (dev->irq)
-+		free_irq(dev->irq, dev);
-+
 +	m_can_clean(dev);
- 
++
  	if (cdev->is_peripheral) {
 -		cdev->tx_skb = NULL;
  		destroy_workqueue(cdev->tx_wq);
  		cdev->tx_wq = NULL;
  		can_rx_offload_disable(&cdev->offload);
-+	} else {
-+		napi_disable(&cdev->napi);
- 	}
- 
- 	close_candev(dev);
- 
-+	m_can_clk_stop(cdev);
- 	phy_power_off(cdev->transceiver);
- 
+@@ -1633,57 +1815,42 @@ static int m_can_close(struct net_device *dev)
  	return 0;
  }
  
@@ -875,7 +787,7 @@ index fb77fd74de27..97cd8bbf2e32 100644
  		if (err)
  			goto out_fail;
  
-@@ -1691,33 +1871,15 @@ static netdev_tx_t m_can_tx_handler(struct m_can_classdev *cdev)
+@@ -1704,33 +1871,15 @@ static netdev_tx_t m_can_tx_handler(struct m_can_classdev *cdev)
  		}
  		m_can_write(cdev, M_CAN_TXBTIE, 0x1);
  
@@ -911,7 +823,7 @@ index fb77fd74de27..97cd8bbf2e32 100644
  
  		/* Construct DLC Field, with CAN-FD configuration.
  		 * Use the put index of the fifo as the message marker,
-@@ -1732,30 +1894,32 @@ static netdev_tx_t m_can_tx_handler(struct m_can_classdev *cdev)
+@@ -1745,30 +1894,32 @@ static netdev_tx_t m_can_tx_handler(struct m_can_classdev *cdev)
  				fdflags |= TX_BUF_BRS;
  		}
  
@@ -937,11 +849,11 @@ index fb77fd74de27..97cd8bbf2e32 100644
  		 * Will be looped back on TX interrupt based on message marker
  		 */
 -		can_put_echo_skb(skb, dev, putidx, 0);
-+		can_put_echo_skb(skb, dev, putidx, frame_len);
- 
+-
 -		/* Enable TX FIFO element to start transfer  */
 -		m_can_write(cdev, M_CAN_TXBAR, (1 << putidx));
--
++		can_put_echo_skb(skb, dev, putidx, frame_len);
+ 
 -		/* stop network queue if fifo full */
 -		if (m_can_tx_fifo_full(cdev) ||
 -		    m_can_next_echo_skb_occupied(dev, putidx))
@@ -958,7 +870,7 @@ index fb77fd74de27..97cd8bbf2e32 100644
  	}
  
  	return NETDEV_TX_OK;
-@@ -1766,54 +1930,108 @@ static netdev_tx_t m_can_tx_handler(struct m_can_classdev *cdev)
+@@ -1779,54 +1930,108 @@ static netdev_tx_t m_can_tx_handler(struct m_can_classdev *cdev)
  	return NETDEV_TX_BUSY;
  }
  
@@ -1082,22 +994,17 @@ index fb77fd74de27..97cd8bbf2e32 100644
 +	if (cdev->can.state == CAN_STATE_BUS_OFF ||
 +	    cdev->can.state == CAN_STATE_STOPPED)
 +		return HRTIMER_NORESTART;
++
++	ret = m_can_interrupt_handler(cdev);
  
 -	m_can_isr(0, cdev->net);
-+	ret = m_can_interrupt_handler(cdev);
-+
 +	/* On error or if napi is scheduled to read, stop the timer */
 +	if (ret < 0 || napi_is_scheduled(&cdev->napi))
 +		return HRTIMER_NORESTART;
  
  	hrtimer_forward_now(timer, ms_to_ktime(HRTIMER_POLL_INTERVAL_MS));
  
-@@ -1842,18 +2060,22 @@ static int m_can_open(struct net_device *dev)
- 
- 	if (cdev->is_peripheral)
- 		can_rx_offload_enable(&cdev->offload);
-+	else
-+		napi_enable(&cdev->napi);
+@@ -1860,15 +2065,17 @@ static int m_can_open(struct net_device *dev)
  
  	/* register interrupt handler */
  	if (cdev->is_peripheral) {
@@ -1119,26 +1026,7 @@ index fb77fd74de27..97cd8bbf2e32 100644
  
  		err = request_threaded_irq(dev->irq, NULL, m_can_isr,
  					   IRQF_ONESHOT,
-@@ -1873,9 +2095,6 @@ static int m_can_open(struct net_device *dev)
- 	if (err)
- 		goto exit_start_fail;
- 
--	if (!cdev->is_peripheral)
--		napi_enable(&cdev->napi);
--
- 	netif_start_queue(dev);
- 
- 	return 0;
-@@ -1889,6 +2108,8 @@ static int m_can_open(struct net_device *dev)
- out_wq_fail:
- 	if (cdev->is_peripheral)
- 		can_rx_offload_disable(&cdev->offload);
-+	else
-+		napi_disable(&cdev->napi);
- 	close_candev(dev);
- exit_disable_clks:
- 	m_can_clk_stop(cdev);
-@@ -1904,15 +2125,121 @@ static const struct net_device_ops m_can_netdev_ops = {
+@@ -1918,15 +2125,121 @@ static const struct net_device_ops m_can_netdev_ops = {
  	.ndo_change_mtu = can_change_mtu,
  };
  
@@ -1262,7 +1150,7 @@ index fb77fd74de27..97cd8bbf2e32 100644
  
  	return register_candev(dev);
  }
-@@ -2060,12 +2387,23 @@ int m_can_class_register(struct m_can_classdev *cdev)
+@@ -2074,12 +2387,23 @@ int m_can_class_register(struct m_can_classdev *cdev)
  {
  	int ret;
  
@@ -1290,7 +1178,7 @@ index fb77fd74de27..97cd8bbf2e32 100644
  	if (cdev->is_peripheral) {
  		ret = can_rx_offload_add_manual(cdev->net, &cdev->offload,
  						NAPI_POLL_WEIGHT);
-@@ -2073,14 +2411,21 @@ int m_can_class_register(struct m_can_classdev *cdev)
+@@ -2087,14 +2411,21 @@ int m_can_class_register(struct m_can_classdev *cdev)
  			goto clk_disable;
  	}
  
@@ -1314,7 +1202,7 @@ index fb77fd74de27..97cd8bbf2e32 100644
  	if (ret) {
  		dev_err(cdev->dev, "registering %s failed (err=%d)\n",
  			cdev->net->name, ret);
-@@ -2125,7 +2470,18 @@ int m_can_class_suspend(struct device *dev)
+@@ -2139,7 +2470,18 @@ int m_can_class_suspend(struct device *dev)
  	if (netif_running(ndev)) {
  		netif_stop_queue(ndev);
  		netif_device_detach(ndev);
@@ -1334,7 +1222,7 @@ index fb77fd74de27..97cd8bbf2e32 100644
  		m_can_clk_stop(cdev);
  	}
  
-@@ -2152,11 +2508,22 @@ int m_can_class_resume(struct device *dev)
+@@ -2166,11 +2508,22 @@ int m_can_class_resume(struct device *dev)
  		ret = m_can_clk_start(cdev);
  		if (ret)
  			return ret;
@@ -1449,7 +1337,7 @@ index f2219aa2824b..9ad7419f88f8 100644
  
  	pci_set_drvdata(pci, mcan_class);
 diff --git a/drivers/net/can/m_can/m_can_platform.c b/drivers/net/can/m_can/m_can_platform.c
-index cdb28d6a092c..b832566efda0 100644
+index e5477775992e..0b9cbb1f2810 100644
 --- a/drivers/net/can/m_can/m_can_platform.c
 +++ b/drivers/net/can/m_can/m_can_platform.c
 @@ -68,7 +68,7 @@ static int iomap_write_fifo(struct m_can_classdev *cdev, int offset,
@@ -1490,7 +1378,7 @@ index cdb28d6a092c..b832566efda0 100644
  
  module_platform_driver(m_can_plat_driver);
 diff --git a/drivers/net/can/m_can/tcan4x5x-core.c b/drivers/net/can/m_can/tcan4x5x-core.c
-index ae8c42f5debd..2f73bf3abad8 100644
+index 4d440ecfc211..b6c5c8bab739 100644
 --- a/drivers/net/can/m_can/tcan4x5x-core.c
 +++ b/drivers/net/can/m_can/tcan4x5x-core.c
 @@ -357,7 +357,7 @@ static int tcan4x5x_get_gpios(struct m_can_classdev *cdev,
@@ -1502,7 +1390,7 @@ index ae8c42f5debd..2f73bf3abad8 100644
  	.init = tcan4x5x_init,
  	.read_reg = tcan4x5x_read_reg,
  	.write_reg = tcan4x5x_write_reg,
-@@ -411,6 +411,7 @@ static int tcan4x5x_can_probe(struct spi_device *spi)
+@@ -412,6 +412,7 @@ static int tcan4x5x_can_probe(struct spi_device *spi)
  	priv->spi = spi;
  
  	mcan_class->pm_clock_support = 0;
@@ -1510,7 +1398,7 @@ index ae8c42f5debd..2f73bf3abad8 100644
  	mcan_class->can.clock.freq = freq;
  	mcan_class->dev = &spi->dev;
  	mcan_class->ops = &tcan4x5x_ops;
-@@ -452,13 +453,23 @@ static int tcan4x5x_can_probe(struct spi_device *spi)
+@@ -453,13 +454,23 @@ static int tcan4x5x_can_probe(struct spi_device *spi)
  		goto out_power;
  	}
  
@@ -1537,7 +1425,7 @@ index ae8c42f5debd..2f73bf3abad8 100644
  	ret = m_can_class_register(mcan_class);
  	if (ret) {
  		dev_err(&spi->dev, "Failed registering m_can device %pe\n",
-@@ -487,6 +498,29 @@ static void tcan4x5x_can_remove(struct spi_device *spi)
+@@ -488,6 +499,29 @@ static void tcan4x5x_can_remove(struct spi_device *spi)
  	m_can_class_free_dev(priv->cdev.net);
  }
  
@@ -1567,7 +1455,7 @@ index ae8c42f5debd..2f73bf3abad8 100644
  static const struct of_device_id tcan4x5x_of_match[] = {
  	{
  		.compatible = "ti,tcan4x5x",
-@@ -505,11 +539,15 @@ static const struct spi_device_id tcan4x5x_id_table[] = {
+@@ -506,11 +540,15 @@ static const struct spi_device_id tcan4x5x_id_table[] = {
  };
  MODULE_DEVICE_TABLE(spi, tcan4x5x_id_table);
  
@@ -1585,7 +1473,7 @@ index ae8c42f5debd..2f73bf3abad8 100644
  	.id_table = tcan4x5x_id_table,
  	.probe = tcan4x5x_can_probe,
 diff --git a/include/linux/netdevice.h b/include/linux/netdevice.h
-index b8e60a20416b..75408f3675a1 100644
+index 030d9de2ba2d..9beb1bbe2901 100644
 --- a/include/linux/netdevice.h
 +++ b/include/linux/netdevice.h
 @@ -480,6 +480,30 @@ static inline bool napi_prefer_busy_poll(struct napi_struct *n)
@@ -1620,5 +1508,5 @@ index b8e60a20416b..75408f3675a1 100644
  
  /**
 -- 
-2.34.1
+2.47.3
 

--- a/dynamic-layers/variscite-nxp-layer/recipes-kernel/linux/linux-variscite/0004-tcan114x-add-driver-with-normal-standby-sleep-mode.patch
+++ b/dynamic-layers/variscite-nxp-layer/recipes-kernel/linux/linux-variscite/0004-tcan114x-add-driver-with-normal-standby-sleep-mode.patch
@@ -1,6 +1,6 @@
-From f005c8eac676948d9b49c7003ba69927630d037e Mon Sep 17 00:00:00 2001
-From: OpenEmbedded <oe.patch@oe>
-Date: Fri, 7 Feb 2025 09:04:48 +0000
+From 607e9ade653199031db9a961d97817eeb281915e Mon Sep 17 00:00:00 2001
+From: rikardo <rikard.olander@hostmobility.com>
+Date: Tue, 21 Apr 2026 12:04:36 +0200
 Subject: [PATCH 1/1] misc: add tcan114x CAN transceiver driver
 
 Add driver for Texas Instruments TCAN114x series CAN transceivers
@@ -382,5 +382,5 @@ index 000000000000..88f683e80f20
 +MODULE_DESCRIPTION("ti tcan114x CAN transceiver SPI driver");
 +MODULE_LICENSE("GPL");
 -- 
-2.25.1
+2.47.3
 

--- a/dynamic-layers/variscite-nxp-layer/recipes-kernel/linux/linux-variscite/0005-marvell-88q2xxx-with-correct-initialization.patch
+++ b/dynamic-layers/variscite-nxp-layer/recipes-kernel/linux/linux-variscite/0005-marvell-88q2xxx-with-correct-initialization.patch
@@ -1,7 +1,7 @@
-From 1ff97c8063c8f749c989ac9dbce7311a9861b8f2 Mon Sep 17 00:00:00 2001
+From fd74ee9903f2f8d012cec39840f82a6120dd2be6 Mon Sep 17 00:00:00 2001
 From: Andreas Ternstedt <a.ternstedt@setek.se>
-Date: Thu, 18 Dec 2025 15:50:22 +0100
-Subject: [PATCH] net: phy: marvell-88q2xxx: Add 88Q2110 A2 initialization support
+Date: Tue, 21 Apr 2026 12:05:08 +0200
+Subject: [PATCH 1/1] net: phy: marvell-88q2xxx: Add 88Q2110 A2 initialization support
 
 Add complete support for Marvell 88Q2110 A2 Automotive Ethernet PHYs
 with enhanced driver initialization.
@@ -577,5 +577,5 @@ index 1c3ff77de56b..b1c1d0341891 100644
  };
  
 -- 
-2.34.1
+2.47.3
 

--- a/dynamic-layers/variscite-nxp-layer/recipes-kernel/linux/linux-variscite/0018-power-reset-gpio-poweroff-add-force-mode.patch
+++ b/dynamic-layers/variscite-nxp-layer/recipes-kernel/linux/linux-variscite/0018-power-reset-gpio-poweroff-add-force-mode.patch
@@ -1,6 +1,6 @@
-From 5d7a513d3932da1a8663e2de9423213c6f6c1ee4 Mon Sep 17 00:00:00 2001
+From 02dacd44a0302a98e4ce625a594381efb29d0c23 Mon Sep 17 00:00:00 2001
 From: Rikardo-hm <rikard.olander@hostmobility.com>
-Date: Mon, 3 Feb 2025 13:59:23 +0000
+Date: Tue, 21 Apr 2026 12:06:52 +0200
 Subject: [PATCH 1/1] power reset gpio poweroff add force mode adapt to kernel 6.6
 
 Property "force-mode" tells the driver to replace previously
@@ -81,5 +81,5 @@ index b28f24da1b3c..fffbc9f5cdbb 100644
  	return 0;
  }
 -- 
-2.25.1
+2.47.3
 

--- a/dynamic-layers/variscite-nxp-layer/recipes-kernel/linux/linux-variscite/0022-gpio-keys-make-disabled-keys-not-wake-system.patch
+++ b/dynamic-layers/variscite-nxp-layer/recipes-kernel/linux/linux-variscite/0022-gpio-keys-make-disabled-keys-not-wake-system.patch
@@ -1,6 +1,6 @@
-From a57d28e4e1aaa44b0bd587d54239e17935cf3452 Mon Sep 17 00:00:00 2001
+From 6915a6204d3da55bf792c79341be3656d4abbf22 Mon Sep 17 00:00:00 2001
 From: Rikardo-hm <rikard.olander@hostmobility.com>
-Date: Mon, 3 Feb 2025 13:51:12 +0000
+Date: Tue, 21 Apr 2026 12:07:47 +0200
 Subject: [PATCH 1/1] gpio-keys: make disabled keys not wake system
 
 Keys can be disabled from generating event, e.g. when KEY_MACRO1(defined
@@ -15,10 +15,10 @@ Modify driver so wake-up only occurs if a key has NOT been disabled.
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/drivers/input/keyboard/gpio_keys.c b/drivers/input/keyboard/gpio_keys.c
-index 2e7c2c046e67..c8eabec61c26 100644
+index a34b9533d8f1..f309f5582c86 100644
 --- a/drivers/input/keyboard/gpio_keys.c
 +++ b/drivers/input/keyboard/gpio_keys.c
-@@ -957,7 +957,7 @@ gpio_keys_enable_wakeup(struct gpio_keys_drvdata *ddata)
+@@ -959,7 +959,7 @@ gpio_keys_enable_wakeup(struct gpio_keys_drvdata *ddata)
  
  	for (i = 0; i < ddata->pdata->nbuttons; i++) {
  		bdata = &ddata->data[i];
@@ -28,5 +28,5 @@ index 2e7c2c046e67..c8eabec61c26 100644
  			if (error)
  				goto err_out;
 -- 
-2.25.1
+2.47.3
 

--- a/dynamic-layers/variscite-nxp-layer/recipes-kernel/linux/linux-variscite/0030-gpio-pca953x-driver-minimize-error-print-out.patch
+++ b/dynamic-layers/variscite-nxp-layer/recipes-kernel/linux/linux-variscite/0030-gpio-pca953x-driver-minimize-error-print-out.patch
@@ -1,16 +1,15 @@
-From 42612514d1dbf7dd68ebe2b0911e08fa03525d21 Mon Sep 17 00:00:00 2001
-From: Rikardo-hm <rikard.olander@hostmobility.com>
-Date: Mon, 3 Feb 2025 13:50:09 +0000
+From c25328a2571c2b02914477982231bab91ddca891 Mon Sep 17 00:00:00 2001
+From: OpenEmbedded <oe.patch@oe>
+Date: Tue, 21 Apr 2026 12:08:12 +0200
 Subject: [PATCH 1/1] gpio-pca953x: fix return and driver minimize error print out
   Return all failures as ret variable in resume. 
   Adapt to kernel 6.6
-
 ---
- drivers/gpio/gpio-pca953x.c | 38 ++++++++++++++++++++++++-------------
- 1 file changed, 25 insertions(+), 13 deletions(-)
+ drivers/gpio/gpio-pca953x.c | 28 +++++++++++++++++++---------
+ 1 file changed, 19 insertions(+), 9 deletions(-)
 
 diff --git a/drivers/gpio/gpio-pca953x.c b/drivers/gpio/gpio-pca953x.c
-index 3cb416fb3d31..27af6da89d2d 100644
+index 57e058ec30f6..bbbbb47544c7 100644
 --- a/drivers/gpio/gpio-pca953x.c
 +++ b/drivers/gpio/gpio-pca953x.c
 @@ -480,6 +480,8 @@ static u8 pcal6534_recalc_addr(struct pca953x_chip *chip, int reg, int off)
@@ -59,25 +58,8 @@ index 3cb416fb3d31..27af6da89d2d 100644
  	}
  
  	for (i = 0; i < NBANK(chip); i++)
-@@ -1292,10 +1304,12 @@ static int pca953x_resume(struct device *dev)
- 	int ret;
- 
- 	if (!atomic_read(&chip->wakeup_path)) {
--		ret = regulator_enable(chip->regulator);
--		if (ret) {
--			dev_err(dev, "Failed to enable regulator: %d\n", ret);
--			return 0;
-+		if (chip->regulator) {
-+			ret = regulator_enable(chip->regulator);
-+			if (ret) {
-+				dev_err(dev, "Failed to enable regulator: %d\n", ret);
-+				return ret;
-+			}
+@@ -1294,7 +1306,7 @@ static int pca953x_resume(struct device *dev)
  		}
- 	}
- 
-@@ -1315,7 +1329,7 @@ static int pca953x_resume(struct device *dev)
- 		return ret;
  	}
  
 -	return 0;
@@ -85,7 +67,7 @@ index 3cb416fb3d31..27af6da89d2d 100644
  }
  #endif
  
-@@ -1380,9 +1394,7 @@ static SIMPLE_DEV_PM_OPS(pca953x_pm_ops, pca953x_suspend, pca953x_resume);
+@@ -1359,9 +1371,7 @@ static SIMPLE_DEV_PM_OPS(pca953x_pm_ops, pca953x_suspend, pca953x_resume);
  static struct i2c_driver pca953x_driver = {
  	.driver = {
  		.name	= "pca953x",
@@ -96,5 +78,5 @@ index 3cb416fb3d31..27af6da89d2d 100644
  		.acpi_match_table = pca953x_acpi_ids,
  	},
 -- 
-2.25.1
+2.47.3
 

--- a/dynamic-layers/variscite-nxp-layer/recipes-kernel/linux/linux-variscite_6.6.bbappend
+++ b/dynamic-layers/variscite-nxp-layer/recipes-kernel/linux/linux-variscite_6.6.bbappend
@@ -15,11 +15,11 @@ file://0022-gpio-keys-make-disabled-keys-not-wake-system.patch  \
 file://0030-gpio-pca953x-driver-minimize-error-print-out.patch \
 "
 
-SRCBRANCH = "lf-6.6.y_6.6.52-2.2.0_var01"
+SRCBRANCH = "6.6-2.2.x-imx_var01"
 SRC_URI = "${KERNEL_SRC};branch=${SRCBRANCH}"
-SRCREV = "bf1b1781e47b1388faaf8689bd7296b3a82b8316"
+SRCREV = "a242d114c51c61a84b84ce03cb00dd6573c879b4"
 
-LINUX_VERSION = "6.6.52"
+LINUX_VERSION = "6.6.119"
 LINUX_VERSION_EXTENSION = "-var-lts-next"
 
 COMPATIBLE_MACHINE = "(imx8mp-var-dart-hmx1)"


### PR DESCRIPTION
Change varicite branch to 6.6-2.2.x-imx_var01
linux version 6.6.119

Update all patches with no changes to code.
- only device tree patch has a new comment and the 0003 backport has changes to the code.