### PR TITLE
 hmx: host-watchdog-fw: Bump revision to 1.6

### DIFF
--- a/recipes-bsp/host-watchdog-fw/host-watchdog-fw_1.6.bb
+++ b/recipes-bsp/host-watchdog-fw/host-watchdog-fw_1.6.bb
@@ -14,7 +14,7 @@ LIC_FILES_CHKSUM = " \
     file://${COMMON_LICENSE_DIR}/MPL-2.0;md5=815ca599c9df247a0c7f619bab123dad \
 "
 
-SRCREV = "bbd4ff8703464deeaaa9929951bf4054a3da5705"
+SRCREV = "05e8c9036aca7cdc76455eef30225217efb4051d"
 SRCBRANCH = "main"
 
 DEPENDS += "cmake-native"


### PR DESCRIPTION
Switch from blocking to non-blocking for RPMsg
    send from coprocessor to host, to avoid potential
    deadlocks in the RPMsg communication.
    
   [host-monitor-cocpu-fw](https://github.com/hostmobility/host-monitor-cocpu-fw/commit/05e8c9036aca7cdc76455eef30225217efb4051d)